### PR TITLE
Fix Wayne County Commission scraper blocked by Akamai bot protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ travis/*.json
 
 # output files: local gitignore added to city_scrapers/local_outputs/
 *.csv
+harambe_scrapers/output/

--- a/harambe_scrapers/extractor/wayne_commission/common.py
+++ b/harambe_scrapers/extractor/wayne_commission/common.py
@@ -1,0 +1,37 @@
+"""Shared HTTP constants and session setup for the Wayne County Commission scraper.
+
+The county site sits behind Akamai bot protection that rejects requests
+pretending to be a desktop browser (spoofed Chrome/Edge User-Agent and
+sec-ch-* headers) when they don't come from a real browser. Plain,
+honestly-identified HTTP clients are allowed, so we identify ourselves
+as a scraper and use the same JSON endpoints the calendar widget uses.
+"""
+
+import requests
+
+BASE_URL = "https://www.waynecountymi.gov"
+CALENDAR_PAGE_URL = f"{BASE_URL}/Government/County-Calendar"
+GET_CALENDARS_URL = f"{BASE_URL}/ocapi/calendars/getcalendars"
+GET_CALENDAR_ITEMS_URL = f"{BASE_URL}/ocapi/calendars/getcalendaritems"
+GET_CONTENT_INFO_URL = f"{BASE_URL}/ocapi/get/contentinfo"
+
+# Fallback for the combined-calendar widget on CALENDAR_PAGE_URL, used if
+# the entity id can't be parsed out of the page HTML.
+DEFAULT_CALENDAR_ENTITY_ID = "126c63c0-c42f-43aa-8168-1867f0ae80f1"
+DEFAULT_CALENDAR_ENTITY_TYPE = "combinedCalendar"
+
+USER_AGENT = "city-scrapers-det (+https://github.com/City-Bureau/city-scrapers-det)"
+
+REQUEST_TIMEOUT = 30
+
+
+def create_session() -> requests.Session:
+    """Create a requests session with an honest User-Agent."""
+    session = requests.Session()
+    session.headers.update(
+        {
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json, text/html;q=0.9, */*;q=0.8",
+        }
+    )
+    return session

--- a/harambe_scrapers/extractor/wayne_commission/detail.py
+++ b/harambe_scrapers/extractor/wayne_commission/detail.py
@@ -47,10 +47,7 @@ def change_timezone(date: str) -> str:
     """Localize a naive ISO datetime string to America/Detroit."""
     naive_datetime = datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
     tz = pytz.timezone(TIMEZONE)
-    localized_datetime = tz.localize(naive_datetime)
-    iso_format = localized_datetime.strftime("%Y-%m-%dT%H:%M:%S%z")
-    # Adjust the offset format to include a colon
-    return iso_format[:-2] + ":" + iso_format[-2:]
+    return tz.localize(naive_datetime).isoformat()
 
 
 def parse_classification(title: Optional[str]) -> Optional[str]:
@@ -150,14 +147,18 @@ def _parse_meeting_layout(selector: Selector) -> dict:
         .replace("Add to Calendar", "")
         .strip()
     )
-    start_time, end_time = time_text.split(" - ")
-
-    start_datetime = datetime.strptime(
-        f"{meeting_date} {start_time.strip()}", "%B %d, %Y %I:%M %p"
-    )
-    end_datetime = datetime.strptime(
-        f"{meeting_date} {end_time.strip()}", "%B %d, %Y %I:%M %p"
-    )
+    start_datetime, end_datetime = None, None
+    if meeting_date and " - " in time_text:
+        start_time, end_time = time_text.split(" - ", 1)
+        try:
+            start_datetime = datetime.strptime(
+                f"{meeting_date} {start_time.strip()}", "%B %d, %Y %I:%M %p"
+            )
+            end_datetime = datetime.strptime(
+                f"{meeting_date} {end_time.strip()}", "%B %d, %Y %I:%M %p"
+            )
+        except ValueError:
+            print(f"    ✗ Could not parse meeting time: {meeting_date} {time_text}")
 
     location_text = _text(selector, "div.meeting-address > p:last-of-type") or ""
     location_text = location_text.replace("View Map", "").strip()

--- a/harambe_scrapers/extractor/wayne_commission/detail.py
+++ b/harambe_scrapers/extractor/wayne_commission/detail.py
@@ -1,215 +1,213 @@
+"""Detail stage for the Wayne County Commission scraper.
+
+Meeting detail pages on waynecountymi.gov are server-rendered, so this
+stage fetches them with plain HTTP and parses the HTML with parsel —
+no browser needed. Two page layouts are handled:
+
+1. The standard meeting layout (`.minutes-details-list`, `.meeting-time`,
+   `.meeting-address`, `.meeting-document`)
+2. A general content layout (`.small-text` date line with a side box)
+"""
+
 import asyncio
 import re
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
-from harambe import SDK
-from harambe.contrib import playwright_harness
-from playwright.async_api import Page, TimeoutError
+import pytz
+from parsel import Selector
+
+from harambe_scrapers.extractor.wayne_commission.common import (
+    BASE_URL,
+    REQUEST_TIMEOUT,
+    create_session,
+)
+
+TIMEZONE = "America/Detroit"
+
+
+def change_timezone(date: str) -> str:
+    """Localize a naive ISO datetime string to America/Detroit."""
+    naive_datetime = datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
+    tz = pytz.timezone(TIMEZONE)
+    localized_datetime = tz.localize(naive_datetime)
+    iso_format = localized_datetime.strftime("%Y-%m-%dT%H:%M:%S%z")
+    # Adjust the offset format to include a colon
+    return iso_format[:-2] + ":" + iso_format[-2:]
+
+
+def parse_classification(title: Optional[str]) -> Optional[str]:
+    title = (title or "").lower()
+
+    classifications = {
+        "committee": "COMMITTEE",
+        "board": "BOARD",
+        "commission": "COMMISION",
+        "public meeting": "PUBLIC",
+        "policy meeting": "POLICY",
+        "community": "COMMUNITY",
+        "annual": "ANNUAL",
+        "cbo": "CBO",
+        "advisory": "ADVISORY",
+        "council": "COUNCIL",
+    }
+
+    for keyword, classification in classifications.items():
+        if keyword in title:
+            return classification
+
+    return None
+
+
+def _text(selector: Selector, css: str) -> Optional[str]:
+    """Joined, whitespace-normalized text of the first element matching css."""
+    matches = selector.css(css)
+    if not matches:
+        return None
+    joined = "".join(matches[0].css("::text").getall())
+    return " ".join(joined.replace("\xa0", " ").split())
+
+
+def _absolute_url(url: str) -> str:
+    if "http" not in url:
+        return BASE_URL + url
+    return url
+
+
+def _parse_links(selector: Selector) -> list[dict]:
+    """Collect document and related-information links (excluding video)."""
+    links = []
+    for document in selector.css(".meeting-document"):
+        title = " ".join(
+            "".join(document.css(".meeting-document-title ::text").getall()).split()
+        )
+        url = document.css("a::attr(href)").get()
+        if not url:
+            continue
+        url = _absolute_url(url)
+        if "youtu" not in url:
+            links.append({"title": title or None, "url": url})
+
+    related = selector.css(
+        ".related-information-section a, .related-information-list a"
+    )
+    for link in related:
+        title = " ".join("".join(link.css("::text").getall()).split())
+        url = link.attrib.get("href")
+        if not url:
+            continue
+        url = _absolute_url(url)
+        if "youtu" not in url:
+            links.append({"title": title, "url": url})
+
+    return links
+
+
+def _parse_meeting_layout(selector: Selector) -> dict:
+    """Parse the standard meeting page layout."""
+    meeting_date = _text(
+        selector, "ul.content-details-list.minutes-details-list span.minutes-date"
+    )
+    meeting_type = _text(
+        selector,
+        "ul.content-details-list.minutes-details-list "
+        "li:nth-child(2) span.field-value",
+    )
+    description = _text(selector, "div.meeting-container > p") or ""
+
+    time_text = (
+        (_text(selector, "div.meeting-time") or "")
+        .replace("Time", "")
+        .replace("Add to Calendar", "")
+        .strip()
+    )
+    start_time, end_time = time_text.split(" - ")
+
+    start_datetime = datetime.strptime(
+        f"{meeting_date} {start_time.strip()}", "%B %d, %Y %I:%M %p"
+    )
+    end_datetime = datetime.strptime(
+        f"{meeting_date} {end_time.strip()}", "%B %d, %Y %I:%M %p"
+    )
+
+    location_text = _text(selector, "div.meeting-address > p:last-of-type") or ""
+    location_text = location_text.replace("View Map", "").strip()
+    location_parts = location_text.split(",", 1)
+    location_name = location_parts[0].strip()
+    location_address = location_parts[1].strip() if len(location_parts) > 1 else ""
+
+    return {
+        "description": description,
+        "start_datetime": start_datetime,
+        "end_datetime": end_datetime,
+        "location_name": location_name,
+        "location_address": location_address,
+        "links": _parse_links(selector),
+        "classification": parse_classification(meeting_type),
+    }
+
+
+def _parse_general_layout(selector: Selector, main_title: str) -> dict:
+    """Parse the fallback general content layout (.small-text date line)."""
+    small_text = "".join(selector.css(".small-text ::text").getall())
+
+    date_match = re.search(r"\b\w+ \d{1,2}, \d{4}, \d{1,2}:\d{2} [AP]M\b", small_text)
+    if date_match:
+        start_datetime = datetime.strptime(date_match.group(0), "%B %d, %Y, %I:%M %p")
+    else:
+        start_datetime = None
+
+    location_name, location_address = None, None
+    location_el = selector.css(".side-box-section p:nth-child(5)")
+    if location_el:
+        location_lines = [
+            line.strip()
+            for line in "".join(location_el[0].css("::text").getall())
+            .replace("\xa0", " ")
+            .split("\n")
+            if line.strip()
+        ]
+        if location_lines:
+            location_name = location_lines[0]
+            location_address = ", ".join(location_lines[1:]).strip()
+
+    description = _text(selector, ".col-m-8 .body-content") or ""
+
+    return {
+        "description": description,
+        "start_datetime": start_datetime,
+        "end_datetime": None,
+        "location_name": location_name,
+        "location_address": location_address,
+        "links": _parse_links(selector),
+        "classification": parse_classification(main_title),
+    }
 
 
 async def scrape(
-    sdk: SDK, current_url: str, context: dict[str, Any], *args: Any, **kwargs: Any
+    sdk: Any, current_url: str, context: dict[str, Any], *args: Any, **kwargs: Any
 ) -> None:
-    page: Page = sdk.page
+    session = kwargs.get("session") or create_session()
 
-    import pytz
+    response = session.get(
+        current_url, headers={"Accept": "text/html"}, timeout=REQUEST_TIMEOUT
+    )
+    response.raise_for_status()
+    selector = Selector(text=response.text)
 
-    async def change_timezone(date):
-        timezone = "America/Detroit"
+    main_title = _text(selector, "h1.oc-page-title")
 
-        # Convert string to naive datetime object
-        naive_datetime = datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
+    if selector.css("ul.content-details-list.minutes-details-list span.minutes-date"):
+        parsed = _parse_meeting_layout(selector)
+    elif selector.css(".small-text"):
+        parsed = _parse_general_layout(selector, main_title)
+    else:
+        print(f"    ✗ Unrecognized page layout: {current_url}")
+        return
 
-        # Get the timezone object
-        tz = pytz.timezone(timezone)
+    start_datetime = parsed["start_datetime"]
+    end_datetime = parsed["end_datetime"]
 
-        # Add timezone to the naive datetime
-        localized_datetime = tz.localize(naive_datetime)
-
-        # Format the localized datetime as ISO 8601 string
-        iso_format = localized_datetime.strftime("%Y-%m-%dT%H:%M:%S%z")
-        # Adjusting the offset format to include a colon
-        iso_format_with_colon = iso_format[:-2] + ":" + iso_format[-2:]
-        return iso_format_with_colon
-
-    def parse_classification(title):
-        title = (title or "").lower()
-
-        # Define mappings of keywords to classification categories
-        classifications = {
-            "committee": "COMMITTEE",
-            "board": "BOARD",
-            "commission": "COMMISION",
-            "public meeting": "PUBLIC",
-            "policy meeting": "POLICY",
-            "community": "COMMUNITY",
-            "annual": "ANNUAL",
-            "cbo": "CBO",
-            "advisory": "ADVISORY",
-            "council": "COUNCIL",
-        }
-
-        # First check the title for each keyword
-        for keyword, classification in classifications.items():
-            if keyword in title:
-                return classification
-
-        return None
-
-    # Wait for the main content to load
-    await page.wait_for_selector("div.main-inner-container")
-
-    # Extract title
-    main_title_element = await page.query_selector("h1.oc-page-title")
-    main_title = await main_title_element.inner_text()
-
-    try:
-        await page.wait_for_selector(
-            "ul.content-details-list.minutes-details-list span.minutes-date"
-        )
-        # Extract meeting date
-        date_element = await page.query_selector(
-            "ul.content-details-list.minutes-details-list span.minutes-date"
-        )
-        meeting_date = await date_element.inner_text()
-
-        # Extract meeting type
-        type_selector = (
-            "ul.content-details-list.minutes-details-list "
-            "li:nth-child(2) span.field-value"
-        )
-        type_element = await page.query_selector(type_selector)
-        meeting_type = await type_element.inner_text()
-
-        # Extract description
-        description_element = await page.query_selector("div.meeting-container > p")
-        description = await description_element.inner_text()
-
-        # Extract start and end time
-        time_element = await page.query_selector("div.meeting-time")
-        time_text = (
-            (await time_element.inner_text())
-            .replace("Time", "")
-            .replace("Add to Calendar", "")
-            .replace("\n", "")
-            .strip()
-        )
-        start_time, end_time = time_text.split(" - ")
-
-        # Combine meeting date with times and convert to datetime objects
-        start_datetime = datetime.strptime(
-            f"{meeting_date} {start_time}", "%B %d, %Y %I:%M %p"
-        )
-        end_datetime = datetime.strptime(
-            f"{meeting_date} {end_time}", "%B %d, %Y %I:%M %p"
-        )
-
-        # Extract location details
-        location_element = await page.query_selector(
-            "div.meeting-address > p:last-of-type"
-        )
-        location_text = await location_element.inner_text()
-        location_parts = location_text.split(",", 1)
-        location_name = location_parts[0].strip()
-        location_address = location_parts[1].strip() if len(location_parts) > 1 else ""
-
-        # Extract links
-        links = []
-        meeting_documents = await page.query_selector_all(".meeting-document")
-        for document in meeting_documents:
-            title_el = await document.query_selector(".meeting-document-title")
-            title = await title_el.inner_text() if title_el else None
-            link = await document.query_selector("a")
-            if not link:
-                continue
-            url = await link.get_attribute("href")
-            if "http" not in url:
-                url = "https://www.waynecountymi.gov" + url
-            if "youtu" not in url:
-                links.append({"title": title, "url": url})
-
-        related_links = await page.query_selector_all(
-            ".related-information-section a, .related-information-list a"
-        )
-        for link in related_links:
-            title = await link.inner_text()
-            url = await link.get_attribute("href")
-            if "http" not in url:
-                url = "https://www.waynecountymi.gov" + url
-            if "youtu" not in url:
-                links.append({"title": title, "url": url})
-
-        classification = parse_classification(meeting_type)
-
-    except TimeoutError:
-        try:
-            await page.wait_for_selector(".small-text")
-            small_text_element = await page.query_selector(".small-text")
-            small_text = await small_text_element.inner_text()
-
-            # Extract date using regex
-            date_match = re.search(
-                "\\b\\w+ \\d{1,2}, \\d{4}, \\d{1,2}:\\d{2} [AP]M\\b", small_text
-            )
-            if date_match:
-                meeting_date = date_match.group(0)
-                start_datetime = datetime.strptime(meeting_date, "%B %d, %Y, %I:%M %p")
-                end_datetime = None
-            else:
-                start_datetime = None
-                end_datetime = None
-
-            # Extract location
-            location_element = await page.query_selector(
-                ".side-box-section p:nth-child(5)"
-            )
-            if location_element:
-                location_text = await location_element.inner_text()
-                location_parts = location_text.split("\n")
-                location_name = location_parts[0].strip()
-                location_address = ", ".join(location_parts[1:]).strip()
-            else:
-                location_name, location_address = (None, None)
-
-            # Extract description
-            description_element = await page.query_selector(".col-m-8 .body-content")
-            description = await description_element.inner_text()
-
-            # Extract links
-            links = []
-            related_links = await page.query_selector_all(
-                ".related-information-section a, .related-information-list a"
-            )
-            for link in related_links:
-                title = await link.inner_text()
-                url = await link.get_attribute("href")
-                if "http" not in url:
-                    url = "https://www.waynecountymi.gov" + url
-                if "youtu" not in url:
-                    links.append({"title": title, "url": url})
-
-            meeting_documents = await page.query_selector_all(".meeting-document")
-            for document in meeting_documents:
-                title_el = await document.query_selector(".meeting-document-title")
-                title = await title_el.inner_text() if title_el else None
-                link = await document.query_selector("a")
-                if not link:
-                    continue
-                url = await link.get_attribute("href")
-                if "http" not in url:
-                    url = "https://www.waynecountymi.gov" + url
-                if "youtu" not in url:
-                    links.append({"title": title, "url": url})
-
-            classification = parse_classification(main_title)
-        except TimeoutError:
-            return
-        except AttributeError:
-            raise AttributeError(
-                "AttributeError: Some of the required fields couldn't be "
-                "extracted, you might wanna incorporate this page's structure"
-            )
     is_all_day_event = (
         True
         if start_datetime
@@ -218,27 +216,27 @@ async def scrape(
         else None
     )
 
-    is_cancelled = True if context["isCancelled"] == "True" else None
+    is_cancelled = True if context.get("isCancelled") == "True" else None
 
     if start_datetime:
-        # Save data
         await sdk.save_data(
             {
                 "title": main_title,
-                "description": description,
-                "classification": classification,
-                "start_time": await change_timezone(start_datetime.isoformat()),
+                "description": parsed["description"],
+                "classification": parsed["classification"],
+                "start_time": change_timezone(start_datetime.isoformat()),
                 "end_time": (
-                    await change_timezone(end_datetime.isoformat())
-                    if end_datetime
-                    else None
+                    change_timezone(end_datetime.isoformat()) if end_datetime else None
                 ),
                 "location": (
-                    {"name": location_name, "address": location_address}
-                    if location_name or location_address
+                    {
+                        "name": parsed["location_name"],
+                        "address": parsed["location_address"],
+                    }
+                    if parsed["location_name"] or parsed["location_address"]
                     else None
                 ),
-                "links": links,
+                "links": parsed["links"],
                 "time_notes": "",
                 "is_cancelled": is_cancelled,
                 "is_all_day_event": is_all_day_event,
@@ -247,119 +245,19 @@ async def scrape(
 
 
 if __name__ == "__main__":
+    # Minimal manual run against a single detail page
+    class _PrintSDK:
+        async def save_data(self, data):
+            import json
+
+            print(json.dumps(data, indent=2))
+
     asyncio.run(
-        SDK.run(
-            scrape,
+        scrape(
+            _PrintSDK(),
             "https://www.waynecountymi.gov/Government/Elected-Officials/"
             "Commission/Committees/Full-Commission/Full-Commission-Meetings/"
-            "Full-Commission-February-1-2024",
-            headless=False,
-            harness=playwright_harness,
-            schema={
-                "links": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "url": {
-                                "type": "string",
-                                "description": (
-                                    "The URL link to the document or "
-                                    "resource related to the meeting."
-                                ),
-                            },
-                            "title": {
-                                "type": "string",
-                                "description": (
-                                    "The title or label for the link, providing "
-                                    "context for what the document or resource is."
-                                ),
-                            },
-                        },
-                        "description": (
-                            "List of dictionaries with title and href for "
-                            "relevant links (eg. agenda, minutes). Empty list "
-                            "if no relevant links are available."
-                        ),
-                    },
-                    "description": (
-                        "A list of links related to the meeting, such as "
-                        "references to meeting agendas, minutes, or other documents."
-                    ),
-                },
-                "title": {
-                    "type": "string",
-                    "description": (
-                        "Title of the meeting (e.g., 'Regular council meeting')."
-                    ),
-                },
-                "end_time": {
-                    "type": "datetime",
-                    "description": (
-                        "The scheduled end time of the meeting. Often unavailable."
-                    ),
-                },
-                "location": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": (
-                                "The name of the venue where the meeting will "
-                                "take place."
-                            ),
-                        },
-                        "address": {
-                            "type": "string",
-                            "description": (
-                                "The full address of the meeting venue. Sometimes, "
-                                "it will include an online meeting link if the "
-                                "physical location is not provided."
-                            ),
-                        },
-                    },
-                    "description": (
-                        "Details about the meeting's location, including the "
-                        "name and address of the venue."
-                    ),
-                },
-                "start_time": {
-                    "type": "datetime",
-                    "description": "The scheduled start time of the meeting.",
-                },
-                "time_notes": {
-                    "type": "string",
-                    "description": (
-                        "If needed, a note about the meeting time. Empty string "
-                        "otherwise. Typically empty string."
-                    ),
-                },
-                "description": {
-                    "type": "string",
-                    "description": (
-                        "Specific meeting description; empty string if unavailable."
-                    ),
-                },
-                "is_cancelled": {
-                    "type": "boolean",
-                    "description": (
-                        "If there are any fields in the site that shows that "
-                        "the meeting has been cancelled True."
-                    ),
-                },
-                "classification": {
-                    "type": "string",
-                    "expression": "UPPER(classification)",
-                    "description": (
-                        "The classification of the meeting, such as "
-                        "'Regular Business Meeting', 'Norcross Development Authority', "
-                        "'City Council Work Session' etc."
-                    ),
-                },
-                "is_all_day_event": {
-                    "type": "boolean",
-                    "description": "Boolean for all-day events. Typically False.",
-                },
-            },
+            "2025/Full-Commission-January-8-2026",
+            {"isCancelled": "False"},
         )
     )

--- a/harambe_scrapers/extractor/wayne_commission/detail.py
+++ b/harambe_scrapers/extractor/wayne_commission/detail.py
@@ -14,7 +14,6 @@ import re
 from datetime import datetime
 from typing import Any, Optional
 
-import pytz
 from parsel import Selector
 
 from harambe_scrapers.extractor.wayne_commission.common import (
@@ -22,19 +21,27 @@ from harambe_scrapers.extractor.wayne_commission.common import (
     REQUEST_TIMEOUT,
     create_session,
 )
+from harambe_scrapers.utils import localize_iso_datetime
 
 TIMEZONE = "America/Detroit"
 
 # Zoom URLs often appear as plain text (not anchors) in the meeting
-# description or location paragraphs
-ZOOM_URL_RE = re.compile(r"https?://[\w.-]*zoom\.us/[^\s\"'<>\\)]+", re.IGNORECASE)
+# description or location paragraphs; the scheme is sometimes omitted
+ZOOM_URL_RE = re.compile(r"(?:https?://)?[\w.-]*zoom\.us/[^\s\"'<>\\)]+", re.IGNORECASE)
 
 # Meetings are sometimes cancelled only via the description text while the
-# calendar API's IsCancelled flag stays false
+# calendar API's IsCancelled flag stays false. Requires "meeting ...
+# cancelled" order or a bare "Cancelled Meeting" description so that text
+# like "the cancelled meeting from June has been rescheduled" doesn't
+# flag the current meeting.
 CANCELLED_TEXT_RE = re.compile(
-    r"\b(meeting\s+(has\s+been\s+)?cancell?ed|cancell?ed\s+meeting)\b",
+    r"\bmeeting\s+(has\s+been\s+|is\s+|was\s+)?cancell?ed\b"
+    r"|^\s*cancell?ed\s+meeting\.?\s*$",
     re.IGNORECASE,
 )
+
+# Time ranges are usually "10:00 AM - 11:00 AM" but tolerate en/em dashes
+TIME_RANGE_SEPARATOR_RE = re.compile(r"\s+[-–—]\s+")
 
 # Containers that hold meeting-specific content on both page layouts
 MEETING_CONTENT_CSS = (
@@ -45,9 +52,7 @@ MEETING_CONTENT_CSS = (
 
 def change_timezone(date: str) -> str:
     """Localize a naive ISO datetime string to America/Detroit."""
-    naive_datetime = datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
-    tz = pytz.timezone(TIMEZONE)
-    return tz.localize(naive_datetime).isoformat()
+    return localize_iso_datetime(date, TIMEZONE)
 
 
 def parse_classification(title: Optional[str]) -> Optional[str]:
@@ -123,6 +128,8 @@ def _add_zoom_links(selector: Selector, links: list[dict]) -> list[dict]:
     content_text = " ".join(selector.css(MEETING_CONTENT_CSS).getall())
     for match in ZOOM_URL_RE.findall(content_text):
         url = match.rstrip(".,;")
+        if not url.lower().startswith("http"):
+            url = "https://" + url
         if url not in existing:
             existing.add(url)
             links.append({"title": "Zoom Meeting Link", "url": url})
@@ -150,7 +157,9 @@ def _parse_meeting_layout(selector: Selector) -> dict:
     # Some pages publish only a start time (no " - <end time>" range)
     start_datetime, end_datetime = None, None
     if meeting_date and time_text:
-        start_time, _, end_time = time_text.partition(" - ")
+        time_parts = TIME_RANGE_SEPARATOR_RE.split(time_text, maxsplit=1)
+        start_time = time_parts[0]
+        end_time = time_parts[1] if len(time_parts) > 1 else ""
         try:
             start_datetime = datetime.strptime(
                 f"{meeting_date} {start_time.strip()}", "%B %d, %Y %I:%M %p"
@@ -182,7 +191,7 @@ def _parse_meeting_layout(selector: Selector) -> dict:
     }
 
 
-def _parse_general_layout(selector: Selector, main_title: str) -> dict:
+def _parse_general_layout(selector: Selector, main_title: str, url: str) -> dict:
     """Parse the fallback general content layout (.small-text date line)."""
     small_text = "".join(selector.css(".small-text ::text").getall())
 
@@ -190,10 +199,15 @@ def _parse_general_layout(selector: Selector, main_title: str) -> dict:
     if date_match:
         start_datetime = datetime.strptime(date_match.group(0), "%B %d, %Y, %I:%M %p")
     else:
+        # Distinguish "page structure changed" from "no date on this page"
+        # so a markup regression doesn't silently drop meetings
+        print(f"    ⚠ No date found in .small-text layout: {url}")
         start_datetime = None
 
     location_name, location_address = None, None
     location_el = selector.css(".side-box-section p:nth-child(5)")
+    if not location_el:
+        print(f"    ⚠ No location element in .small-text layout: {url}")
     if location_el:
         location_lines = [
             line.strip()
@@ -235,7 +249,7 @@ async def scrape(
     if selector.css("ul.content-details-list.minutes-details-list span.minutes-date"):
         parsed = _parse_meeting_layout(selector)
     elif selector.css(".small-text"):
-        parsed = _parse_general_layout(selector, main_title)
+        parsed = _parse_general_layout(selector, main_title, current_url)
     else:
         print(f"    ✗ Unrecognized page layout: {current_url}")
         return

--- a/harambe_scrapers/extractor/wayne_commission/detail.py
+++ b/harambe_scrapers/extractor/wayne_commission/detail.py
@@ -25,6 +25,23 @@ from harambe_scrapers.extractor.wayne_commission.common import (
 
 TIMEZONE = "America/Detroit"
 
+# Zoom URLs often appear as plain text (not anchors) in the meeting
+# description or location paragraphs
+ZOOM_URL_RE = re.compile(r"https?://[\w.-]*zoom\.us/[^\s\"'<>\\)]+", re.IGNORECASE)
+
+# Meetings are sometimes cancelled only via the description text while the
+# calendar API's IsCancelled flag stays false
+CANCELLED_TEXT_RE = re.compile(
+    r"\b(meeting\s+(has\s+been\s+)?cancell?ed|cancell?ed\s+meeting)\b",
+    re.IGNORECASE,
+)
+
+# Containers that hold meeting-specific content on both page layouts
+MEETING_CONTENT_CSS = (
+    ".meeting-container ::text, .meeting-address ::text, "
+    ".body-content ::text, .side-box-section ::text"
+)
+
 
 def change_timezone(date: str) -> str:
     """Localize a naive ISO datetime string to America/Detroit."""
@@ -100,6 +117,18 @@ def _parse_links(selector: Selector) -> list[dict]:
         if "youtu" not in url:
             links.append({"title": title, "url": url})
 
+    return links
+
+
+def _add_zoom_links(selector: Selector, links: list[dict]) -> list[dict]:
+    """Add Zoom URLs that appear as plain text in the meeting content."""
+    existing = {link["url"].rstrip(".") for link in links}
+    content_text = " ".join(selector.css(MEETING_CONTENT_CSS).getall())
+    for match in ZOOM_URL_RE.findall(content_text):
+        url = match.rstrip(".,;")
+        if url not in existing:
+            existing.add(url)
+            links.append({"title": "Zoom Meeting Link", "url": url})
     return links
 
 
@@ -216,7 +245,13 @@ async def scrape(
         else None
     )
 
+    links = _add_zoom_links(selector, parsed["links"])
+
     is_cancelled = True if context.get("isCancelled") == "True" else None
+    # The county sometimes cancels a meeting only in the description text
+    # without flagging it in the calendar API
+    if not is_cancelled and CANCELLED_TEXT_RE.search(parsed["description"] or ""):
+        is_cancelled = True
 
     if start_datetime:
         await sdk.save_data(
@@ -236,7 +271,7 @@ async def scrape(
                     if parsed["location_name"] or parsed["location_address"]
                     else None
                 ),
-                "links": parsed["links"],
+                "links": links,
                 "time_notes": "",
                 "is_cancelled": is_cancelled,
                 "is_all_day_event": is_all_day_event,

--- a/harambe_scrapers/extractor/wayne_commission/detail.py
+++ b/harambe_scrapers/extractor/wayne_commission/detail.py
@@ -147,18 +147,23 @@ def _parse_meeting_layout(selector: Selector) -> dict:
         .replace("Add to Calendar", "")
         .strip()
     )
+    # Some pages publish only a start time (no " - <end time>" range)
     start_datetime, end_datetime = None, None
-    if meeting_date and " - " in time_text:
-        start_time, end_time = time_text.split(" - ", 1)
+    if meeting_date and time_text:
+        start_time, _, end_time = time_text.partition(" - ")
         try:
             start_datetime = datetime.strptime(
                 f"{meeting_date} {start_time.strip()}", "%B %d, %Y %I:%M %p"
             )
-            end_datetime = datetime.strptime(
-                f"{meeting_date} {end_time.strip()}", "%B %d, %Y %I:%M %p"
-            )
         except ValueError:
             print(f"    ✗ Could not parse meeting time: {meeting_date} {time_text}")
+        if start_datetime and end_time.strip():
+            try:
+                end_datetime = datetime.strptime(
+                    f"{meeting_date} {end_time.strip()}", "%B %d, %Y %I:%M %p"
+                )
+            except ValueError:
+                pass
 
     location_text = _text(selector, "div.meeting-address > p:last-of-type") or ""
     location_text = location_text.replace("View Map", "").strip()

--- a/harambe_scrapers/extractor/wayne_commission/listing.py
+++ b/harambe_scrapers/extractor/wayne_commission/listing.py
@@ -137,18 +137,36 @@ async def scrape(
     # Previous year through next year, so late-year scrapes still pick up
     # meetings already booked for January onward.
     current_year = datetime.datetime.now().year
+    years = range(current_year - 1, current_year + 2)
+    seen_items = set()
     seen_urls = set()
     enqueued = 0
-    for year in range(current_year - 1, current_year + 2):
-        items = get_calendar_items(
-            session, calendar_ids, f"{year}-01-01", f"{year}-12-31"
-        )
+    failed_years = 0
+    failed_items = 0
+    for year in years:
+        # A transient failure for one year shouldn't abort the whole scrape
+        try:
+            items = get_calendar_items(
+                session, calendar_ids, f"{year}-01-01", f"{year}-12-31"
+            )
+        except Exception as e:
+            print(f"[LISTING] ✗ Failed to fetch calendar items for {year}: {e}")
+            failed_years += 1
+            continue
         print(f"[LISTING] Year {year}: {len(items)} calendar items")
 
         for item in items:
+            # A multi-day item appears once per date group; dedup before
+            # spending a contentinfo request on it
+            item_key = (item.get("CalendarId"), item.get("Id"))
+            if item_key in seen_items:
+                continue
+            seen_items.add(item_key)
+
             info = get_content_info(session, item)
             await asyncio.sleep(ITEM_REQUEST_DELAY_SECONDS)
             if not info:
+                failed_items += 1
                 continue
             meeting_link = info.get("Link")
             if not meeting_link or meeting_link in seen_urls:
@@ -162,6 +180,21 @@ async def scrape(
             enqueued += 1
             if enqueued % 20 == 0:
                 print(f"[LISTING]   ✓ Enqueued {enqueued} meeting URLs so far...")
+
+    if failed_years:
+        print(f"[LISTING] ⚠ {failed_years}/{len(years)} year fetches failed")
+    if failed_items:
+        print(f"[LISTING] ⚠ {failed_items} contentinfo lookups failed")
+
+    # The county always has meetings booked, so an empty result means
+    # something systemic broke (e.g. bot protection rules changed). Fail
+    # loudly rather than let the cron report a "successful" empty run.
+    if enqueued == 0:
+        raise RuntimeError(
+            "Listing stage enqueued 0 meeting URLs "
+            f"({failed_years} year fetches and {failed_items} contentinfo "
+            "lookups failed) — treating an empty calendar as a scraper failure"
+        )
 
     print(f"[LISTING] Scrape complete! Total URLs enqueued: {enqueued}")
 

--- a/harambe_scrapers/extractor/wayne_commission/listing.py
+++ b/harambe_scrapers/extractor/wayne_commission/listing.py
@@ -1,358 +1,175 @@
+"""Listing stage for the Wayne County Commission scraper.
+
+Collects meeting detail-page URLs from the county's OpenCities calendar
+JSON API. The flow mirrors what the calendar widget on
+/Government/County-Calendar does in the browser:
+
+1. GET the calendar page and read the combined-calendar widget's entity id
+2. GET /ocapi/calendars/getcalendars/{entityId}/{entityType} for the list
+   of calendars (Full Commission, each committee, etc.)
+3. POST /ocapi/calendars/getcalendaritems for each year's items
+4. GET /ocapi/get/contentinfo per item for the detail-page link and
+   cancellation status
+
+Everything is plain HTTP — no browser. The site's Akamai bot protection
+rejects spoofed browser headers from non-browser clients, so we identify
+ourselves honestly instead (see common.py).
+"""
+
 import asyncio
 import datetime
+import re
+import time
 from typing import Any
 
-import pytz
-import requests
-from harambe import SDK
-from harambe.contrib import playwright_harness
-from playwright.async_api import Page
+from harambe_scrapers.extractor.wayne_commission.common import (
+    CALENDAR_PAGE_URL,
+    DEFAULT_CALENDAR_ENTITY_ID,
+    DEFAULT_CALENDAR_ENTITY_TYPE,
+    GET_CALENDAR_ITEMS_URL,
+    GET_CALENDARS_URL,
+    GET_CONTENT_INFO_URL,
+    REQUEST_TIMEOUT,
+    create_session,
+)
+
+# Delay between per-item contentinfo requests to stay polite
+ITEM_REQUEST_DELAY_SECONDS = 0.1
+
+
+def get_calendar_entity(session) -> tuple[str, str]:
+    """Read the combined-calendar widget's entity id/type from the page."""
+    try:
+        response = session.get(
+            CALENDAR_PAGE_URL,
+            headers={"Accept": "text/html"},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        match = re.search(
+            r"data-entity-id='([0-9a-fA-F-]+)'\s+data-entity-type=(\w+)",
+            response.text,
+        )
+        if match:
+            return match.group(1), match.group(2)
+        print(
+            "[LISTING] Could not find calendar widget in page HTML, "
+            "falling back to known entity id"
+        )
+    except Exception as e:
+        print(f"[LISTING] Error fetching calendar page ({e}), using fallback id")
+    return DEFAULT_CALENDAR_ENTITY_ID, DEFAULT_CALENDAR_ENTITY_TYPE
+
+
+def get_calendars(session, entity_id: str, entity_type: str) -> list[dict]:
+    """Fetch the calendars (Full Commission + committees) for the widget."""
+    url = f"{GET_CALENDARS_URL}/{entity_id}/{entity_type}"
+    response = session.get(url, timeout=REQUEST_TIMEOUT)
+    response.raise_for_status()
+    body = response.json()
+    if not body.get("success"):
+        raise RuntimeError(f"getcalendars returned success=false: {body}")
+    return body.get("data", [])
+
+
+def get_calendar_items(
+    session, calendar_ids: list[str], start_date: str, end_date: str
+) -> list[dict]:
+    """Fetch calendar items for the given calendars and date range."""
+    payload = {
+        "LanguageCode": "en-US",
+        "Ids": calendar_ids,
+        "StartDate": start_date,
+        "EndDate": end_date,
+    }
+    response = session.post(
+        GET_CALENDAR_ITEMS_URL, json=payload, timeout=REQUEST_TIMEOUT
+    )
+    response.raise_for_status()
+    body = response.json()
+    if not body.get("success"):
+        raise RuntimeError(f"getcalendaritems returned success=false: {body}")
+    items = []
+    for group in body.get("data", []):
+        items.extend(group.get("Items", []))
+    return items
+
+
+def get_content_info(session, item: dict) -> dict | None:
+    """Fetch detail info (link, cancellation status) for a calendar item."""
+    now = datetime.datetime.now()
+    params = {
+        "calendarId": item["CalendarId"],
+        "contentId": item["Id"],
+        "language": "en-US",
+        "currentDateTime": now.strftime("%m/%d/%Y %I:%M:%S %p"),
+        "mainContentId": item["MainContentId"],
+    }
+    response = session.get(GET_CONTENT_INFO_URL, params=params, timeout=REQUEST_TIMEOUT)
+    if response.status_code != 200:
+        print(
+            f"[LISTING]   Warning: Got status {response.status_code} "
+            f"for contentinfo call ({item.get('Name')})"
+        )
+        return None
+    body = response.json()
+    return body.get("data") or None
 
 
 async def scrape(
-    sdk: SDK, current_url: str, context: dict[str, Any], *args: Any, **kwargs: Any
+    sdk: Any, current_url: str, context: dict[str, Any], *args: Any, **kwargs: Any
 ) -> None:
     print(f"[LISTING] Starting listing scrape for URL: {current_url}")
-    page: Page = sdk.page
+    session = kwargs.get("session") or create_session()
 
-    async def change_timezone(date):
-        timezone = "America/Detroit"
+    entity_id, entity_type = get_calendar_entity(session)
+    print(f"[LISTING] Calendar widget entity: {entity_id} ({entity_type})")
 
-        # Convert string to naive datetime object
-        naive_datetime = datetime.datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
+    calendars = get_calendars(session, entity_id, entity_type)
+    calendar_ids = [c["Id"] for c in calendars if c.get("Id")]
+    print(f"[LISTING] Found {len(calendar_ids)} calendars:")
+    for calendar in calendars:
+        print(f"[LISTING]   - {calendar.get('Label')}")
 
-        # Get the timezone object
-        tz = pytz.timezone(timezone)
+    if not calendar_ids:
+        raise RuntimeError("No calendars found for the county calendar widget")
 
-        # Add timezone to the naive datetime
-        localized_datetime = tz.localize(naive_datetime)
-
-        # Format the localized datetime as ISO 8601 string
-        iso_format = localized_datetime.strftime("%Y-%m-%dT%H:%M:%S%z")
-        # Adjusting the offset format to include a colon
-        iso_format_with_colon = iso_format[:-2] + ":" + iso_format[-2:]
-        return iso_format_with_colon
-
-    def parse_classification(title):
-        title = (title or "").lower()
-
-        # Define mappings of keywords to classification categories
-        classifications = {
-            "committee": "COMMITTEE",
-            "board": "BOARD",
-            "commission": "COMMISION",
-            "public meeting": "PUBLIC",
-            "policy meeting": "POLICY",
-            "community": "COMMUNITY",
-            "annual": "ANNUAL",
-            "cbo": "CBO",
-            "advisory": "ADVISORY",
-            "council": "COUNCIL",
-        }
-
-        # First check the title for each keyword
-        for keyword, classification in classifications.items():
-            if keyword in title:
-                return classification
-
-        return None
-
-    scraperId = []
-    print("[LISTING] Starting page navigation...")
-    await page.goto("https://www.waynecountymi.gov/Government/County-Calendar")
-    print("[LISTING] Page loaded, waiting for calendar filter...")
-    await page.wait_for_selector(".calendar-filter")
-    print("[LISTING] Calendar filter found, getting meeting types...")
-    meeting_types = await page.query_selector_all(".calendar-filter-list-item")
-    print(f"[LISTING] Found {len(meeting_types)} meeting types")
-    for type in meeting_types:
-        ID = await type.get_attribute("data-filter-option-id")
-        scraperId.append(ID)
-
-    print(f"[LISTING] Collected {len(scraperId)} scraper IDs")
-    if scraperId:
-        # Get the current year
-        current_year = datetime.datetime.now().year
-        print(
-            f"[LISTING] Starting API calls for years {current_year - 1} "
-            f"to {current_year}"
+    # Previous year through next year, so late-year scrapes still pick up
+    # meetings already booked for January onward.
+    current_year = datetime.datetime.now().year
+    seen_urls = set()
+    enqueued = 0
+    for year in range(current_year - 1, current_year + 2):
+        items = get_calendar_items(
+            session, calendar_ids, f"{year}-01-01", f"{year}-12-31"
         )
+        print(f"[LISTING] Year {year}: {len(items)} calendar items")
 
-        # Loop from one year less than the current year to the current year
-        for year in range(current_year - 1, current_year + 1):
-            print(f"[LISTING] Processing year {year}...")
-            url = "https://www.waynecountymi.gov/ocapi/calendars/getcalendaritems"
-
-            payload = (
-                f'{{"LanguageCode":"en-US","Ids":{scraperId},'
-                f'"StartDate":"{year}-01-01","EndDate":"{year}-12-31"}}'
+        for item in items:
+            info = get_content_info(session, item)
+            time.sleep(ITEM_REQUEST_DELAY_SECONDS)
+            if not info:
+                continue
+            meeting_link = info.get("Link")
+            if not meeting_link or meeting_link in seen_urls:
+                continue
+            seen_urls.add(meeting_link)
+            is_cancelled = info.get("IsCancelled") is not False
+            await sdk.enqueue(
+                meeting_link,
+                context={"isCancelled": f"{is_cancelled}"},
             )
+            enqueued += 1
+            if enqueued % 20 == 0:
+                print(f"[LISTING]   ✓ Enqueued {enqueued} meeting URLs so far...")
 
-            headers = {
-                "accept": "application/json, text/javascript, */*; q=0.01",
-                "accept-language": (
-                    "es-419,es;q=0.9,es-ES;q=0.8,en;q=0.7,en-GB;q=0.6,"
-                    "en-US;q=0.5,ar;q=0.4,ur;q=0.3,es-MX;q=0.2"
-                ),
-                "content-type": "application/json; charset=UTF-8",
-                "origin": "https://www.waynecountymi.gov",
-                "priority": "u=1, i",
-                "referer": "https://www.waynecountymi.gov/Government/County-Calendar",
-                "sec-ch-ua": (
-                    '"Not)A;Brand";v="8", "Chromium";v="138", '
-                    '"Microsoft Edge";v="138"'
-                ),
-                "sec-ch-ua-mobile": "?0",
-                "sec-ch-ua-platform": '"Windows"',
-                "sec-fetch-dest": "empty",
-                "sec-fetch-mode": "cors",
-                "sec-fetch-site": "same-origin",
-                "user-agent": (
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-                    "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0"
-                ),
-                "x-b3-sampled": "1",
-                "x-b3-spanid": "8637d509111f36c5",
-                "x-b3-traceid": "b1fb5355028f0b97b4d23cd37b51d7ee",
-                "x-oracle-apm-ba-version": "1.1.131",
-                "x-requested-with": "XMLHttpRequest",
-                "Cookie": "ASP.NET_SessionId=h4ooyutzz33houczonxywo0h",
-            }
-
-            print(f"[LISTING] Making API POST to {url}")
-            response = requests.request("POST", url, headers=headers, data=payload)
-            print(f"[LISTING] API Response status: {response.status_code}")
-            if response.status_code == 200:
-                data = response.json()
-                data_items = data.get("data", [])
-                print(
-                    f"[LISTING] Found {len(data_items)} calendar groups for year {year}"
-                )
-                total_meetings = 0
-                meetings_processed = 0
-                for idx, meeting in enumerate(data_items):
-                    meeting_items = meeting.get("Items", [])
-                    total_meetings += len(meeting_items)
-                    if len(meeting_items) > 0:  # Only print if there are items
-                        print(
-                            f"[LISTING] Processing calendar group {idx + 1}/"
-                            f"{len(data_items)}, with {len(meeting_items)} items"
-                        )
-                    for item_idx, item in enumerate(meeting_items):
-                        calendarId = item["CalendarId"]
-                        contentId = item["Id"]
-                        mainContentId = item["MainContentId"]
-                        itemDate = item["DateTime"]
-                        # Note: itemDate is used for display/logging purposes
-
-                        # Get the current date and time
-                        now = datetime.datetime.now()
-
-                        # Format the date and time in the desired format
-                        formatted_date_time = now.strftime("%m/%d/%Y%%20%I:%M:%S%%20%p")
-
-                        url = (
-                            f"https://www.waynecountymi.gov/ocapi/get/contentinfo?"
-                            f"calendarId={calendarId}&contentId={contentId}&"
-                            f"language=en-US&currentDateTime={formatted_date_time}&"
-                            f"mainContentId={mainContentId}"
-                        )
-
-                        # Print progress every 5 items or on first/last item
-                        if (
-                            item_idx == 0
-                            or item_idx % 5 == 0
-                            or item_idx == len(meeting_items) - 1
-                        ):
-                            print(
-                                f"[LISTING]   Processing item {item_idx + 1}/"
-                                f"{len(meeting_items)} - Date: {itemDate}"
-                            )
-
-                        payload = {}
-                        headers = {
-                            "accept": "application/json, text/javascript, */*; q=0.01",
-                            "accept-language": (
-                                "es-419,es;q=0.9,es-ES;q=0.8,en;q=0.7,en-GB;q=0.6,"
-                                "en-US;q=0.5,ar;q=0.4,ur;q=0.3,es-MX;q=0.2"
-                            ),
-                            "priority": "u=1, i",
-                            "referer": (
-                                "https://www.waynecountymi.gov/Government/"
-                                "County-Calendar"
-                            ),
-                            "sec-ch-ua": (
-                                '"Not)A;Brand";v="8", "Chromium";v="138", '
-                                '"Microsoft Edge";v="138"'
-                            ),
-                            "sec-ch-ua-mobile": "?0",
-                            "sec-ch-ua-platform": '"Windows"',
-                            "sec-fetch-dest": "empty",
-                            "sec-fetch-mode": "cors",
-                            "sec-fetch-site": "same-origin",
-                            "user-agent": (
-                                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                                "Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0"
-                            ),
-                            "x-b3-sampled": "1",
-                            "x-b3-spanid": "b976fbfea423163d",
-                            "x-b3-traceid": "be91badf5d062cf9732c40defae7b6b0",
-                            "x-oracle-apm-ba-version": "1.1.131",
-                            "x-requested-with": "XMLHttpRequest",
-                            "Cookie": "ASP.NET_SessionId=h4ooyutzz33houczonxywo0h",
-                        }
-
-                        response = requests.request(
-                            "GET", url, headers=headers, data=payload
-                        )
-                        if response.status_code == 200:
-                            meeting_data = response.json()
-                            meeting = meeting_data.get("data", {})
-                            meeting_link = meeting.get("Link")
-                            if meeting_link:
-                                is_cancelled = (
-                                    False
-                                    if meeting.get("IsCancelled") is False
-                                    else True
-                                )
-
-                                await sdk.enqueue(
-                                    meeting_link,
-                                    context={"isCancelled": f"{is_cancelled}"},
-                                )
-                                meetings_processed += 1
-                                if meetings_processed % 20 == 0:
-                                    print(
-                                        f"[LISTING]   ✓ Enqueued {meetings_processed} "
-                                        f"meeting URLs so far..."
-                                    )
-                        else:
-                            print(
-                                f"[LISTING]   Warning: Got status "
-                                f"{response.status_code} for meeting API call"
-                            )
-                print(
-                    f"[LISTING] Total meetings processed for year {year}: "
-                    f"{total_meetings}, URLs enqueued: {meetings_processed}"
-                )
-
-    urls_count = len(sdk.detail_urls) if hasattr(sdk, "detail_urls") else "unknown"
-    print(f"[LISTING] Scrape complete! Total URLs enqueued: {urls_count}")
+    print(f"[LISTING] Scrape complete! Total URLs enqueued: {enqueued}")
 
 
 if __name__ == "__main__":
-    asyncio.run(
-        SDK.run(
-            scrape,
-            "https://www.waynecountymi.gov/Government/County-Calendar",
-            headless=False,
-            harness=playwright_harness,
-            schema={
-                "links": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "url": {
-                                "type": "string",
-                                "description": (
-                                    "The URL link to the document or resource "
-                                    "related to the meeting."
-                                ),
-                            },
-                            "title": {
-                                "type": "string",
-                                "description": (
-                                    "The title or label for the link, providing "
-                                    "context for what the document or resource is."
-                                ),
-                            },
-                        },
-                        "description": (
-                            "List of dictionaries with title and href for "
-                            "relevant links (eg. agenda, minutes). Empty list "
-                            "if no relevant links are available."
-                        ),
-                    },
-                    "description": (
-                        "A list of links related to the meeting, such as "
-                        "references to meeting agendas, minutes, or other documents."
-                    ),
-                },
-                "title": {
-                    "type": "string",
-                    "description": (
-                        "Title of the meeting (e.g., 'Regular council meeting')."
-                    ),
-                },
-                "end_time": {
-                    "type": "datetime",
-                    "description": (
-                        "The scheduled end time of the meeting. Often unavailable."
-                    ),
-                },
-                "location": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": (
-                                "The name of the venue where the meeting will "
-                                "take place."
-                            ),
-                        },
-                        "address": {
-                            "type": "string",
-                            "description": (
-                                "The full address of the meeting venue. Sometimes, "
-                                "it will include an online meeting link if the "
-                                "physical location is not provided."
-                            ),
-                        },
-                    },
-                    "description": (
-                        "Details about the meeting's location, including the "
-                        "name and address of the venue."
-                    ),
-                },
-                "start_time": {
-                    "type": "datetime",
-                    "description": "The scheduled start time of the meeting.",
-                },
-                "time_notes": {
-                    "type": "string",
-                    "description": (
-                        "If needed, a note about the meeting time. Empty string "
-                        "otherwise. Typically empty string."
-                    ),
-                },
-                "description": {
-                    "type": "string",
-                    "description": (
-                        "Specific meeting description; empty string if unavailable."
-                    ),
-                },
-                "is_cancelled": {
-                    "type": "boolean",
-                    "description": (
-                        "If there are any fields in the site that shows that "
-                        "the meeting has been cancelled True."
-                    ),
-                },
-                "classification": {
-                    "type": "string",
-                    "expression": "UPPER(classification)",
-                    "description": (
-                        "The classification of the meeting, such as "
-                        "'Regular Business Meeting', 'Norcross Development Authority', "
-                        "'City Council Work Session' etc."
-                    ),
-                },
-                "is_all_day_event": {
-                    "type": "boolean",
-                    "description": "Boolean for all-day events. Typically False.",
-                },
-            },
-        )
-    )
+    # Minimal manual run: collect and print detail URLs
+    class _PrintSDK:
+        async def enqueue(self, url, context=None):
+            print(url, context)
+
+    asyncio.run(scrape(_PrintSDK(), CALENDAR_PAGE_URL, {}))

--- a/harambe_scrapers/extractor/wayne_commission/listing.py
+++ b/harambe_scrapers/extractor/wayne_commission/listing.py
@@ -19,7 +19,6 @@ ourselves honestly instead (see common.py).
 import asyncio
 import datetime
 import re
-import time
 from typing import Any
 
 from harambe_scrapers.extractor.wayne_commission.common import (
@@ -47,7 +46,8 @@ def get_calendar_entity(session) -> tuple[str, str]:
         )
         response.raise_for_status()
         match = re.search(
-            r"data-entity-id='([0-9a-fA-F-]+)'\s+data-entity-type=(\w+)",
+            r"data-entity-id=[\"']?([0-9a-fA-F-]+)[\"']?\s+"
+            r"data-entity-type=[\"']?(\w+)[\"']?",
             response.text,
         )
         if match:
@@ -90,8 +90,8 @@ def get_calendar_items(
     if not body.get("success"):
         raise RuntimeError(f"getcalendaritems returned success=false: {body}")
     items = []
-    for group in body.get("data", []):
-        items.extend(group.get("Items", []))
+    for group in body.get("data") or []:
+        items.extend(group.get("Items") or [])
     return items
 
 
@@ -147,7 +147,7 @@ async def scrape(
 
         for item in items:
             info = get_content_info(session, item)
-            time.sleep(ITEM_REQUEST_DELAY_SECONDS)
+            await asyncio.sleep(ITEM_REQUEST_DELAY_SECONDS)
             if not info:
                 continue
             meeting_link = info.get("Link")

--- a/harambe_scrapers/utils.py
+++ b/harambe_scrapers/utils.py
@@ -10,6 +10,17 @@ from datetime import datetime
 import pytz
 
 
+def localize_iso_datetime(date, timezone="America/Detroit"):
+    """Localize a naive ISO datetime string ("%Y-%m-%dT%H:%M:%S") to the
+    given timezone, returning an ISO 8601 string with a colon in the offset.
+
+    Shared replacement for the per-scraper change_timezone helpers.
+    """
+    naive_datetime = datetime.strptime(date, "%Y-%m-%dT%H:%M:%S")
+    tz = pytz.timezone(timezone)
+    return tz.localize(naive_datetime).isoformat()
+
+
 def slugify(text):
     """Convert text to URL slug format"""
     text = str(text).lower().strip()

--- a/harambe_scrapers/wayne_commission.py
+++ b/harambe_scrapers/wayne_commission.py
@@ -15,19 +15,21 @@ This scraper consolidates all Wayne County Commission meetings including:
 - Election Commission
 - Local Emergency Planning
 - Ethics Board
+
+The county site's Akamai bot protection blocks clients that spoof browser
+headers, so both stages run over plain HTTP with an honest User-Agent
+(see extractor/wayne_commission/common.py) — no browser required.
 """
 
 import asyncio
 import json
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from playwright.async_api import async_playwright
-
+from harambe_scrapers.extractor.wayne_commission.common import create_session
 from harambe_scrapers.extractor.wayne_commission.detail import scrape as detail_scrape
-
-# Import the listing and detail scrapers
 from harambe_scrapers.extractor.wayne_commission.listing import scrape as listing_scrape
 from harambe_scrapers.observers import DataCollector
 from harambe_scrapers.utils import create_ocd_event
@@ -46,12 +48,14 @@ TIMEZONE = "America/Detroit"
 START_URL = "https://www.waynecountymi.gov/Government/County-Calendar"
 OUTPUT_DIR = Path("harambe_scrapers/output")
 
+# Delay between detail-page requests to stay polite
+DETAIL_REQUEST_DELAY_SECONDS = 0.25
+
 
 class ListingSDK:
     """Mock SDK for listing stage that collects URLs."""
 
-    def __init__(self, page, detail_urls):
-        self.page = page
+    def __init__(self, detail_urls):
         self.detail_urls = detail_urls
 
     async def enqueue(self, url: str, context: dict = None):
@@ -62,8 +66,7 @@ class ListingSDK:
 class DetailSDK:
     """Mock SDK for detail stage that stores extracted data."""
 
-    def __init__(self, page):
-        self.page = page
+    def __init__(self):
         self.data = None
 
     async def save_data(self, data: dict):
@@ -74,42 +77,37 @@ class DetailSDK:
 class WayneCommissionOrchestrator:
     """Orchestrator for Wayne County Commission scraper."""
 
-    def __init__(self, headless: bool = True, limit_meetings: int = None):
-        self.headless = headless
+    def __init__(self, limit_meetings: int = None):
         self.limit_meetings = limit_meetings  # Optional limit for testing
         self.observer = DataCollector(
             scraper_name=SCRAPER_NAME,
             timezone=TIMEZONE,
         )
+        self.session = create_session()
         self.detail_urls = []
         self.current_url = None
 
-    async def run_listing_stage(self, page):
+    async def run_listing_stage(self):
         """Run listing stage to collect all detail page URLs."""
         print("\n📋 STAGE 1: Collecting meeting URLs from calendar API...")
 
         try:
-            listing_sdk = ListingSDK(page, self.detail_urls)
-            # Set a reasonable timeout for page operations
-            page.set_default_timeout(30000)  # 30 seconds
-            await listing_scrape(listing_sdk, START_URL, {})
+            listing_sdk = ListingSDK(self.detail_urls)
+            await listing_scrape(listing_sdk, START_URL, {}, session=self.session)
             print(f"  ✓ Found {len(self.detail_urls)} meetings")
         except Exception as e:
             print(f"  ✗ Error during listing stage: {e}")
             raise
 
-    async def run_detail_stage(self, page, detail_info: dict) -> Optional[dict]:
+    async def run_detail_stage(self, detail_info: dict) -> Optional[dict]:
         """Run detail stage for a single meeting."""
         url = detail_info["url"]
         context = detail_info.get("context", {})
 
         try:
             self.current_url = url
-            await page.goto(url, wait_until="domcontentloaded")
-
-            detail_sdk = DetailSDK(page)
-            await detail_scrape(detail_sdk, url, context)
-
+            detail_sdk = DetailSDK()
+            await detail_scrape(detail_sdk, url, context, session=self.session)
             return detail_sdk.data
         except Exception as e:
             print(f"    ✗ Error extracting {url}: {e}")
@@ -145,79 +143,69 @@ class WayneCommissionOrchestrator:
         print(AGENCY_NAME)
         print("=" * 70)
 
-        async with async_playwright() as p:
-            browser = await p.chromium.launch(headless=self.headless)
-            context = await browser.new_context()
-            page = await context.new_page()
+        # Stage 1: Collect all meeting URLs
+        await self.run_listing_stage()
 
-            try:
-                # Stage 1: Collect all meeting URLs
-                await self.run_listing_stage(page)
+        # Stage 2: Extract details from each meeting page
+        print("\n📄 STAGE 2: Extracting meeting details...")
 
-                # Stage 2: Extract details from each meeting page
-                print("\n📄 STAGE 2: Extracting meeting details...")
+        # Apply limit if set (for testing)
+        urls_to_process = self.detail_urls
+        if self.limit_meetings:
+            urls_to_process = self.detail_urls[: self.limit_meetings]
+            print(
+                f"  ⚠️ Limited to processing {self.limit_meetings} meetings "
+                f"(out of {len(self.detail_urls)} total)"
+            )
 
-                # Apply limit if set (for testing)
-                urls_to_process = self.detail_urls
-                if self.limit_meetings:
-                    urls_to_process = self.detail_urls[: self.limit_meetings]
-                    print(
-                        f"  ⚠️ Limited to processing {self.limit_meetings} meetings "
-                        f"(out of {len(self.detail_urls)} total)"
-                    )
+        for i, detail_info in enumerate(urls_to_process, 1):
+            # Show progress percentage
+            progress = (i / len(urls_to_process)) * 100
+            print(f"\n  [{progress:.1f}%] Processing {i}/{len(urls_to_process)}:")
+            print(f"    URL: {detail_info['url']}")
 
-                for i, detail_info in enumerate(urls_to_process, 1):
-                    # Show progress percentage
-                    progress = (i / len(urls_to_process)) * 100
-                    print(
-                        f"\n  [{progress:.1f}%] Processing {i}/{len(urls_to_process)}:"
-                    )
-                    print(f"    URL: {detail_info['url']}")
+            raw_data = await self.run_detail_stage(detail_info)
+            time.sleep(DETAIL_REQUEST_DELAY_SECONDS)
 
-                    raw_data = await self.run_detail_stage(page, detail_info)
+            if raw_data and raw_data.get("start_time"):
+                ocd_event = self.transform_to_ocd_format(raw_data)
+                await self.observer.on_save_data(ocd_event)
+                # Extract date from start_time for display
+                start_date = raw_data["start_time"][:10]  # Get YYYY-MM-DD
+                title = raw_data.get("title", "Unknown")
+                print(f"    ✓ {start_date} - {title}")
+            else:
+                print("    ✗ Skipped (missing start_time or data)")
 
-                    if raw_data and raw_data.get("start_time"):
-                        ocd_event = self.transform_to_ocd_format(raw_data)
-                        await self.observer.on_save_data(ocd_event)
-                        # Extract date from start_time for display
-                        start_date = raw_data["start_time"][:10]  # Get YYYY-MM-DD
-                        title = raw_data.get("title", "Unknown")
-                        print(f"    ✓ {start_date} - {title}")
-                    else:
-                        print("    ✗ Skipped (missing start_time or data)")
+        print("\n" + "=" * 70)
+        print(f"Scraping Complete: {len(self.observer.data)} meetings")
+        print("=" * 70)
 
-                print("\n" + "=" * 70)
-                print(f"Scraping Complete: {len(self.observer.data)} meetings")
-                print("=" * 70)
+        if self.observer.data:
+            OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            output_file = OUTPUT_DIR / f"{OUTPUT_NAME}_{timestamp}.json"
 
-                if self.observer.data:
-                    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-                    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                    output_file = OUTPUT_DIR / f"{OUTPUT_NAME}_{timestamp}.json"
+            with open(output_file, "w", encoding="utf-8") as f:
+                for meeting in self.observer.data:
+                    if "__url" in meeting:
+                        del meeting["__url"]
+                    f.write(json.dumps(meeting, ensure_ascii=False) + "\n")
 
-                    with open(output_file, "w", encoding="utf-8") as f:
-                        for meeting in self.observer.data:
-                            if "__url" in meeting:
-                                del meeting["__url"]
-                            f.write(json.dumps(meeting, ensure_ascii=False) + "\n")
+            print(f"\n✓ Data saved to: {output_file}")
 
-                    print(f"\n✓ Data saved to: {output_file}")
-
-                    if self.observer.azure_client:
-                        print("✓ Data uploaded to Azure Blob Storage")
-                    else:
-                        print(
-                            "ℹ Azure upload not configured "
-                            "(set AZURE_* environment variables)"
-                        )
-
-            finally:
-                await browser.close()
+            if self.observer.azure_client:
+                print("✓ Data uploaded to Azure Blob Storage")
+            else:
+                print(
+                    "ℹ Azure upload not configured "
+                    "(set AZURE_* environment variables)"
+                )
 
 
 async def main():
     # Process all meetings (no limit)
-    orchestrator = WayneCommissionOrchestrator(headless=True)
+    orchestrator = WayneCommissionOrchestrator()
     await orchestrator.run()
 
 

--- a/harambe_scrapers/wayne_commission.py
+++ b/harambe_scrapers/wayne_commission.py
@@ -23,7 +23,6 @@ headers, so both stages run over plain HTTP with an honest User-Agent
 
 import asyncio
 import json
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -165,7 +164,7 @@ class WayneCommissionOrchestrator:
             print(f"    URL: {detail_info['url']}")
 
             raw_data = await self.run_detail_stage(detail_info)
-            time.sleep(DETAIL_REQUEST_DELAY_SECONDS)
+            await asyncio.sleep(DETAIL_REQUEST_DELAY_SECONDS)
 
             if raw_data and raw_data.get("start_time"):
                 ocd_event = self.transform_to_ocd_format(raw_data)

--- a/harambe_scrapers/wayne_commission.py
+++ b/harambe_scrapers/wayne_commission.py
@@ -176,6 +176,15 @@ class WayneCommissionOrchestrator:
             else:
                 print("    ✗ Skipped (missing start_time or data)")
 
+        # URLs were found but nothing parsed — the detail-page markup has
+        # likely changed. Fail loudly so the cron doesn't report a
+        # "successful" run that quietly produced no meetings.
+        if urls_to_process and not self.observer.data:
+            raise RuntimeError(
+                f"Detail stage produced 0 meetings from "
+                f"{len(urls_to_process)} URLs — treating as a scraper failure"
+            )
+
         print("\n" + "=" * 70)
         print(f"Scraping Complete: {len(self.observer.data)} meetings")
         print("=" * 70)

--- a/tests/test_wayne_commission.py
+++ b/tests/test_wayne_commission.py
@@ -1,11 +1,12 @@
 """
 Unit tests for Wayne County Commission scraper (Harambe-based orchestrator).
-Tests the two-stage orchestration (listing->detail).
+Tests the two-stage orchestration (listing->detail) over plain HTTP.
 """
 
+import json
 from datetime import datetime, timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytz
@@ -27,9 +28,19 @@ def get_future_datetime(days_ahead=30):
     )
 
 
+def make_response(json_data=None, text=None, status_code=200):
+    """Build a mock requests response"""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text or (json.dumps(json_data) if json_data else "")
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
 def test_transform_to_ocd_format_with_all_fields():
     """Test transform_to_ocd_format with complete meeting data"""
-    orchestrator = WayneCommissionOrchestrator(headless=True)
+    orchestrator = WayneCommissionOrchestrator()
     orchestrator.current_url = (
         "https://www.waynecountymi.gov/Government/Elected-Officials/test"
     )
@@ -66,7 +77,7 @@ def test_transform_to_ocd_format_with_all_fields():
 
 def test_transform_to_ocd_format_with_cancelled_meeting():
     """Test transform_to_ocd_format correctly handles cancelled meetings"""
-    orchestrator = WayneCommissionOrchestrator(headless=True)
+    orchestrator = WayneCommissionOrchestrator()
     orchestrator.current_url = "https://www.waynecountymi.gov/cancelled"
 
     past_time = (datetime.now() - timedelta(days=30)).isoformat()
@@ -86,23 +97,17 @@ def test_transform_to_ocd_format_with_cancelled_meeting():
 @pytest.mark.asyncio
 async def test_run_listing_stage():
     """Test run_listing_stage collects meeting URLs properly"""
-    orchestrator = WayneCommissionOrchestrator(headless=True)
-
-    mock_page = MagicMock()
-    mock_page.set_default_timeout = MagicMock()
-    mock_page.goto = AsyncMock()
-    mock_page.wait_for_selector = AsyncMock()
-    mock_page.query_selector_all = AsyncMock(return_value=[])
+    orchestrator = WayneCommissionOrchestrator()
 
     with patch("harambe_scrapers.wayne_commission.listing_scrape") as mock_listing:
 
-        async def mock_scrape(sdk, url, context):
+        async def mock_scrape(sdk, url, context, **kwargs):
             await sdk.enqueue("https://meeting1.com", {"isCancelled": "False"})
             await sdk.enqueue("https://meeting2.com", {"isCancelled": "False"})
 
         mock_listing.side_effect = mock_scrape
 
-        await orchestrator.run_listing_stage(mock_page)
+        await orchestrator.run_listing_stage()
 
         assert len(orchestrator.detail_urls) == 2
         assert orchestrator.detail_urls[0]["url"] == "https://meeting1.com"
@@ -111,7 +116,7 @@ async def test_run_listing_stage():
 @pytest.mark.asyncio
 async def test_orchestrator_with_limit():
     """Test that the orchestrator respects the limit_meetings parameter"""
-    orchestrator = WayneCommissionOrchestrator(headless=True, limit_meetings=3)
+    orchestrator = WayneCommissionOrchestrator(limit_meetings=3)
 
     orchestrator.detail_urls = [
         {"url": f"https://test{i}.com", "context": {"isCancelled": "False"}}
@@ -130,89 +135,151 @@ async def test_orchestrator_with_limit():
             with patch.object(orchestrator.observer, "on_save_data") as mock_save:
                 mock_save.return_value = None
 
-                pw_patch = "harambe_scrapers.wayne_commission.async_playwright"
-                with patch(pw_patch) as mock_pw:
-                    mock_browser = AsyncMock()
-                    mock_context = AsyncMock()
-                    mock_page = AsyncMock()
+                await orchestrator.run()
 
-                    mock_chromium = (
-                        mock_pw.return_value.__aenter__.return_value.chromium
-                    )
-                    mock_chromium.launch.return_value = mock_browser
-                    mock_browser.new_context.return_value = mock_context
-                    mock_context.new_page.return_value = mock_page
-                    mock_browser.close = AsyncMock()
-
-                    await orchestrator.run()
-
-                    assert mock_detail.call_count == 3
+                assert mock_detail.call_count == 3
 
 
 @pytest.mark.asyncio
 async def test_listing_scraper_with_mock_api():
-    """Test listing scraper correctly filters meeting types and calls API"""
-    from bs4 import BeautifulSoup
-
+    """Test listing scraper walks the calendar API and enqueues detail URLs"""
     from harambe_scrapers.extractor.wayne_commission.listing import (
         scrape as listing_scrape,
     )
 
-    # Load the listing HTML fixture
-    fixture_path = Path(__file__).parent / "files" / "wayne_commission_listing.html"
-    with open(fixture_path, "r", encoding="utf-8") as f:
-        html_content = f.read()
+    calendar_page_html = (
+        "<div data-entity-id='126c63c0-c42f-43aa-8168-1867f0ae80f1' "
+        "data-entity-type=combinedCalendar class='oc-calendar'></div>"
+    )
+    calendars_response = {
+        "success": True,
+        "data": [
+            {"Id": "cal-full-commission", "Label": "Full Commission Meeting"},
+            {"Id": "cal-ways-means", "Label": "Ways & Means Committee"},
+        ],
+    }
+    items_response = {
+        "success": True,
+        "data": [
+            {
+                "Items": [
+                    {
+                        "CalendarId": "cal-full-commission",
+                        "Id": "item-1",
+                        "MainContentId": "item-1",
+                        "Name": "Full Commission - January 8, 2026",
+                        "DateTime": "1/8/2026 10:00:00 AM",
+                    }
+                ]
+            }
+        ],
+    }
+    empty_items_response = {"success": True, "data": []}
+    content_info_response = {
+        "success": True,
+        "data": {
+            "Title": "Full Commission - January 8, 2026",
+            "Link": "https://www.waynecountymi.gov/meeting-detail",
+            "IsCancelled": False,
+        },
+    }
 
-    soup = BeautifulSoup(html_content, "html.parser")
+    session = MagicMock()
+
+    def fake_get(url, **kwargs):
+        if "County-Calendar" in url:
+            return make_response(text=calendar_page_html)
+        if "getcalendars" in url:
+            return make_response(json_data=calendars_response)
+        if "contentinfo" in url:
+            return make_response(json_data=content_info_response)
+        raise AssertionError(f"Unexpected GET {url}")
+
+    post_responses = iter([empty_items_response, items_response, empty_items_response])
+
+    def fake_post(url, **kwargs):
+        assert "getcalendaritems" in url
+        payload = kwargs["json"]
+        assert payload["Ids"] == ["cal-full-commission", "cal-ways-means"]
+        return make_response(json_data=next(post_responses))
+
+    session.get.side_effect = fake_get
+    session.post.side_effect = fake_post
 
     detail_urls = []
-    mock_page = MagicMock()
-    mock_page.goto = AsyncMock()
-    mock_page.wait_for_selector = AsyncMock()
+    sdk = ListingSDK(detail_urls)
 
-    # Create mock elements for each filter item
-    mock_elements = []
-    filter_items = soup.select(".calendar-filter-list-item")
-    for item in filter_items:
-        mock_elem = MagicMock()
-        mock_elem.get_attribute = AsyncMock(
-            return_value=item.get("data-filter-option-id")
+    with patch(
+        "harambe_scrapers.extractor.wayne_commission.listing."
+        "ITEM_REQUEST_DELAY_SECONDS",
+        0,
+    ):
+        await listing_scrape(sdk, "https://test.com", {}, session=session)
+
+    # One POST per year: previous, current, next
+    assert session.post.call_count == 3
+    assert len(detail_urls) == 1
+    assert detail_urls[0]["url"] == "https://www.waynecountymi.gov/meeting-detail"
+    assert detail_urls[0]["context"]["isCancelled"] == "False"
+
+
+@pytest.mark.asyncio
+async def test_listing_scraper_dedupes_urls():
+    """Duplicate detail links across items should only be enqueued once"""
+    from harambe_scrapers.extractor.wayne_commission.listing import (
+        scrape as listing_scrape,
+    )
+
+    item = {
+        "CalendarId": "cal-1",
+        "Id": "item-1",
+        "MainContentId": "item-1",
+        "Name": "Meeting",
+        "DateTime": "1/8/2026 10:00:00 AM",
+    }
+    items_response = {"success": True, "data": [{"Items": [item, dict(item)]}]}
+    empty_items_response = {"success": True, "data": []}
+
+    session = MagicMock()
+
+    def fake_get(url, **kwargs):
+        if "County-Calendar" in url:
+            return make_response(text="<html></html>")
+        if "getcalendars" in url:
+            return make_response(
+                json_data={"success": True, "data": [{"Id": "cal-1", "Label": "X"}]}
+            )
+        if "contentinfo" in url:
+            return make_response(
+                json_data={
+                    "success": True,
+                    "data": {"Link": "https://example.com/same", "IsCancelled": False},
+                }
+            )
+        raise AssertionError(f"Unexpected GET {url}")
+
+    post_responses = iter([empty_items_response, items_response, empty_items_response])
+    session.get.side_effect = fake_get
+    session.post.side_effect = lambda url, **kwargs: make_response(
+        json_data=next(post_responses)
+    )
+
+    detail_urls = []
+    with patch(
+        "harambe_scrapers.extractor.wayne_commission.listing."
+        "ITEM_REQUEST_DELAY_SECONDS",
+        0,
+    ):
+        await listing_scrape(
+            ListingSDK(detail_urls), "https://test.com", {}, session=session
         )
 
-        text_elem = item.select_one(".calendar-filter-list-item-text")
-        mock_text = MagicMock()
-        mock_text.inner_text = AsyncMock(return_value=text_elem.get_text(strip=True))
-        mock_elem.query_selector = AsyncMock(return_value=mock_text)
-
-        mock_elements.append(mock_elem)
-
-    mock_page.query_selector_all = AsyncMock(return_value=mock_elements)
-
-    sdk = ListingSDK(mock_page, detail_urls)
-
-    req_patch = "harambe_scrapers.extractor.wayne_commission.listing.requests.request"
-    with patch(req_patch) as mock_request:
-        mock_request.return_value.status_code = 200
-        mock_request.return_value.json.return_value = {"data": []}
-
-        await listing_scrape(sdk, "https://test.com", {})
-
-        # Verify API was called for both years (current and previous)
-        assert mock_request.called
-        assert mock_request.call_count == 2
-
-        # Verify the scraper identified the correct meeting types from the HTML
-        call_args = mock_request.call_args_list[0][1]["data"]
-        # The payload should contain the IDs for the expected meeting types
-        # Full Commission or Ways & Means
-        assert "1001" in call_args or "1002" in call_args
+    assert len(detail_urls) == 1
 
 
 @pytest.mark.asyncio
 async def test_detail_scraper_with_html_fixture():
     """Test detail scraper extracts all data correctly from real HTML fixture"""
-    from bs4 import BeautifulSoup
-
     from harambe_scrapers.extractor.wayne_commission.detail import (
         scrape as detail_scrape,
     )
@@ -221,64 +288,13 @@ async def test_detail_scraper_with_html_fixture():
     with open(fixture_path, "r", encoding="utf-8") as f:
         html_content = f.read()
 
-    soup = BeautifulSoup(html_content, "html.parser")
+    session = MagicMock()
+    session.get.return_value = make_response(text=html_content)
 
-    mock_page = MagicMock()
-    mock_page.wait_for_selector = AsyncMock()
-
-    def create_element_mock(element):
-        if element is None:
-            return None
-        mock_elem = MagicMock()
-        text = (
-            element.get_text(strip=True)
-            if hasattr(element, "get_text")
-            else str(element)
-        )
-        mock_elem.inner_text = AsyncMock(return_value=text)
-        if element.name == "a" and element.get("href"):
-            mock_elem.get_attribute = AsyncMock(return_value=element.get("href"))
-        return mock_elem
-
-    async def mock_query_selector(selector):
-        element = soup.select_one(selector)
-        return create_element_mock(element)
-
-    async def mock_query_selector_all(selector):
-        elements = soup.select(selector)
-        mock_elements = []
-        for elem in elements:
-            mock_elem = MagicMock()
-            if "meeting-document" in selector:
-                title_elem = elem.select_one(".meeting-document-title")
-                link_elem = elem.select_one("a")
-
-                def make_query_selector(title_el, link_el):
-                    async def query_doc_element(s):
-                        if "title" in s and title_el:
-                            return create_element_mock(title_el)
-                        elif "a" in s and link_el:
-                            return create_element_mock(link_el)
-                        return None
-
-                    return query_doc_element
-
-                mock_elem.query_selector = AsyncMock(
-                    side_effect=make_query_selector(title_elem, link_elem)
-                )
-            else:
-                mock_elem = create_element_mock(elem)
-
-            mock_elements.append(mock_elem)
-        return mock_elements
-
-    mock_page.query_selector = AsyncMock(side_effect=mock_query_selector)
-    mock_page.query_selector_all = AsyncMock(side_effect=mock_query_selector_all)
-
-    sdk = DetailSDK(mock_page)
+    sdk = DetailSDK()
     context = {"isCancelled": "False"}
 
-    await detail_scrape(sdk, "https://test.com", context)
+    await detail_scrape(sdk, "https://test.com", context, session=session)
 
     assert sdk.data is not None
     assert sdk.data["title"] == "Full Commission - February 1, 2024"
@@ -308,3 +324,26 @@ async def test_detail_scraper_with_html_fixture():
             assert link["url"].startswith("https://www.waynecountymi.gov")
 
     assert sdk.data["is_cancelled"] is None  # False context means None in the code
+
+
+@pytest.mark.asyncio
+async def test_detail_scraper_cancelled_context():
+    """Cancelled context flag should carry through to the saved data"""
+    from harambe_scrapers.extractor.wayne_commission.detail import (
+        scrape as detail_scrape,
+    )
+
+    fixture_path = Path(__file__).parent / "files" / "wayne_commission.html"
+    with open(fixture_path, "r", encoding="utf-8") as f:
+        html_content = f.read()
+
+    session = MagicMock()
+    session.get.return_value = make_response(text=html_content)
+
+    sdk = DetailSDK()
+    await detail_scrape(
+        sdk, "https://test.com", {"isCancelled": "True"}, session=session
+    )
+
+    assert sdk.data is not None
+    assert sdk.data["is_cancelled"] is True

--- a/tests/test_wayne_commission.py
+++ b/tests/test_wayne_commission.py
@@ -114,7 +114,7 @@ async def test_run_listing_stage():
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_with_limit():
+async def test_orchestrator_with_limit(tmp_path):
     """Test that the orchestrator respects the limit_meetings parameter"""
     orchestrator = WayneCommissionOrchestrator(limit_meetings=3)
 
@@ -132,12 +132,30 @@ async def test_orchestrator_with_limit():
                 "start_time": datetime.now().isoformat(),
             }
 
-            with patch.object(orchestrator.observer, "on_save_data") as mock_save:
-                mock_save.return_value = None
-
+            with patch("harambe_scrapers.wayne_commission.OUTPUT_DIR", tmp_path):
                 await orchestrator.run()
 
                 assert mock_detail.call_count == 3
+                assert len(orchestrator.observer.data) == 3
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_raises_when_no_meetings_parse():
+    """URLs found but zero meetings parsed should fail loudly, not succeed"""
+    orchestrator = WayneCommissionOrchestrator()
+
+    orchestrator.detail_urls = [
+        {"url": "https://test.com", "context": {"isCancelled": "False"}}
+    ]
+
+    with patch.object(orchestrator, "run_listing_stage") as mock_listing:
+        mock_listing.return_value = None
+
+        with patch.object(orchestrator, "run_detail_stage") as mock_detail:
+            mock_detail.return_value = None  # every page fails to parse
+
+            with pytest.raises(RuntimeError, match="0 meetings"):
+                await orchestrator.run()
 
 
 @pytest.mark.asyncio
@@ -424,3 +442,258 @@ async def test_detail_scraper_start_time_only():
     assert "2026-01-14T09:30:00" in sdk.data["start_time"]
     assert sdk.data["end_time"] is None
     assert sdk.data["title"] == "Seniors and Veterans Affairs Committee"
+
+
+@pytest.mark.asyncio
+async def test_listing_scraper_survives_one_year_failure():
+    """A failed year fetch should be skipped, not abort the whole scrape"""
+    from harambe_scrapers.extractor.wayne_commission.listing import (
+        scrape as listing_scrape,
+    )
+
+    item = {
+        "CalendarId": "cal-1",
+        "Id": "item-1",
+        "MainContentId": "item-1",
+        "Name": "Meeting",
+        "DateTime": "1/8/2026 10:00:00 AM",
+    }
+    items_response = {"success": True, "data": [{"Items": [item]}]}
+
+    session = MagicMock()
+
+    def fake_get(url, **kwargs):
+        if "County-Calendar" in url:
+            return make_response(text="<html></html>")
+        if "getcalendars" in url:
+            return make_response(
+                json_data={"success": True, "data": [{"Id": "cal-1", "Label": "X"}]}
+            )
+        if "contentinfo" in url:
+            return make_response(
+                json_data={
+                    "success": True,
+                    "data": {"Link": "https://example.com/m1", "IsCancelled": False},
+                }
+            )
+        raise AssertionError(f"Unexpected GET {url}")
+
+    # First year's fetch blows up; the other two succeed
+    post_responses = iter(
+        [
+            ConnectionError("transient failure"),
+            items_response,
+            {"success": True, "data": []},
+        ]
+    )
+
+    def fake_post(url, **kwargs):
+        result = next(post_responses)
+        if isinstance(result, Exception):
+            raise result
+        return make_response(json_data=result)
+
+    session.get.side_effect = fake_get
+    session.post.side_effect = fake_post
+
+    detail_urls = []
+    with patch(
+        "harambe_scrapers.extractor.wayne_commission.listing."
+        "ITEM_REQUEST_DELAY_SECONDS",
+        0,
+    ):
+        await listing_scrape(
+            ListingSDK(detail_urls), "https://test.com", {}, session=session
+        )
+
+    assert session.post.call_count == 3
+    assert len(detail_urls) == 1
+
+
+@pytest.mark.asyncio
+async def test_listing_scraper_raises_on_zero_meetings():
+    """An empty scrape should fail loudly instead of reporting success"""
+    from harambe_scrapers.extractor.wayne_commission.listing import (
+        scrape as listing_scrape,
+    )
+
+    session = MagicMock()
+
+    def fake_get(url, **kwargs):
+        if "County-Calendar" in url:
+            return make_response(text="<html></html>")
+        if "getcalendars" in url:
+            return make_response(
+                json_data={"success": True, "data": [{"Id": "cal-1", "Label": "X"}]}
+            )
+        raise AssertionError(f"Unexpected GET {url}")
+
+    session.get.side_effect = fake_get
+    session.post.return_value = make_response(json_data={"success": True, "data": []})
+
+    with pytest.raises(RuntimeError, match="0 meeting URLs"):
+        await listing_scrape(ListingSDK([]), "https://test.com", {}, session=session)
+
+
+@pytest.mark.asyncio
+async def test_listing_scraper_dedupes_before_contentinfo_fetch():
+    """Duplicate calendar items shouldn't cost an extra contentinfo request"""
+    from harambe_scrapers.extractor.wayne_commission.listing import (
+        scrape as listing_scrape,
+    )
+
+    item = {
+        "CalendarId": "cal-1",
+        "Id": "item-1",
+        "MainContentId": "item-1",
+        "Name": "Meeting",
+        "DateTime": "1/8/2026 10:00:00 AM",
+    }
+    items_response = {"success": True, "data": [{"Items": [item, dict(item)]}]}
+    empty_response = {"success": True, "data": []}
+
+    session = MagicMock()
+    contentinfo_calls = []
+
+    def fake_get(url, **kwargs):
+        if "County-Calendar" in url:
+            return make_response(text="<html></html>")
+        if "getcalendars" in url:
+            return make_response(
+                json_data={"success": True, "data": [{"Id": "cal-1", "Label": "X"}]}
+            )
+        if "contentinfo" in url:
+            contentinfo_calls.append(kwargs.get("params"))
+            return make_response(
+                json_data={
+                    "success": True,
+                    "data": {"Link": "https://example.com/m1", "IsCancelled": False},
+                }
+            )
+        raise AssertionError(f"Unexpected GET {url}")
+
+    post_responses = iter([empty_response, items_response, empty_response])
+    session.get.side_effect = fake_get
+    session.post.side_effect = lambda url, **kwargs: make_response(
+        json_data=next(post_responses)
+    )
+
+    detail_urls = []
+    with patch(
+        "harambe_scrapers.extractor.wayne_commission.listing."
+        "ITEM_REQUEST_DELAY_SECONDS",
+        0,
+    ):
+        await listing_scrape(
+            ListingSDK(detail_urls), "https://test.com", {}, session=session
+        )
+
+    assert len(contentinfo_calls) == 1
+    assert len(detail_urls) == 1
+
+
+def _detail_fixture_html(description, meeting_time="Time 9:00 AM - 10:00 AM"):
+    return f"""
+    <html><body>
+    <h1 class="oc-page-title">Test Committee - July 20, 2026</h1>
+    <ul class="content-details-list minutes-details-list">
+      <li><span class="minutes-date">July 20, 2026</span></li>
+      <li><span class="field-value">Test Committee</span></li>
+    </ul>
+    <div class="meeting-container"><p>{description}</p></div>
+    <div class="meeting-time">{meeting_time}</div>
+    <div class="meeting-address"><p>Guardian Building, 500 Griswold</p></div>
+    </body></html>
+    """
+
+
+@pytest.mark.asyncio
+async def test_detail_scraper_cancellation_text_no_false_positive():
+    """A reference to a different cancelled meeting shouldn't flag this one"""
+    from harambe_scrapers.extractor.wayne_commission.detail import (
+        scrape as detail_scrape,
+    )
+
+    session = MagicMock()
+    session.get.return_value = make_response(
+        text=_detail_fixture_html(
+            "The cancelled meeting from June has been rescheduled to July 20."
+        )
+    )
+
+    sdk = DetailSDK()
+    await detail_scrape(
+        sdk, "https://test.com", {"isCancelled": "False"}, session=session
+    )
+
+    assert sdk.data is not None
+    assert sdk.data["is_cancelled"] is None
+
+
+@pytest.mark.asyncio
+async def test_detail_scraper_bare_cancelled_meeting_description():
+    """A description that is just 'Cancelled Meeting' should flag cancellation"""
+    from harambe_scrapers.extractor.wayne_commission.detail import (
+        scrape as detail_scrape,
+    )
+
+    session = MagicMock()
+    session.get.return_value = make_response(
+        text=_detail_fixture_html("Cancelled Meeting")
+    )
+
+    sdk = DetailSDK()
+    await detail_scrape(
+        sdk, "https://test.com", {"isCancelled": "False"}, session=session
+    )
+
+    assert sdk.data is not None
+    assert sdk.data["is_cancelled"] is True
+
+
+@pytest.mark.asyncio
+async def test_detail_scraper_en_dash_time_range():
+    """Time ranges separated by an en dash should still parse"""
+    from harambe_scrapers.extractor.wayne_commission.detail import (
+        scrape as detail_scrape,
+    )
+
+    session = MagicMock()
+    session.get.return_value = make_response(
+        text=_detail_fixture_html(
+            "Standard Meeting", meeting_time="Time 9:00 AM – 10:30 AM"
+        )
+    )
+
+    sdk = DetailSDK()
+    await detail_scrape(
+        sdk, "https://test.com", {"isCancelled": "False"}, session=session
+    )
+
+    assert sdk.data is not None
+    assert "2026-07-20T09:00:00" in sdk.data["start_time"]
+    assert "2026-07-20T10:30:00" in sdk.data["end_time"]
+
+
+@pytest.mark.asyncio
+async def test_detail_scraper_protocol_less_zoom_link():
+    """A zoom.us reference without a scheme should still become a link"""
+    from harambe_scrapers.extractor.wayne_commission.detail import (
+        scrape as detail_scrape,
+    )
+
+    session = MagicMock()
+    session.get.return_value = make_response(
+        text=_detail_fixture_html("Join at zoom.us/j/999888777.")
+    )
+
+    sdk = DetailSDK()
+    await detail_scrape(
+        sdk, "https://test.com", {"isCancelled": "False"}, session=session
+    )
+
+    assert sdk.data is not None
+    zoom_links = [link for link in sdk.data["links"] if "zoom.us" in link["url"]]
+    assert zoom_links == [
+        {"title": "Zoom Meeting Link", "url": "https://zoom.us/j/999888777"}
+    ]

--- a/tests/test_wayne_commission.py
+++ b/tests/test_wayne_commission.py
@@ -347,3 +347,43 @@ async def test_detail_scraper_cancelled_context():
 
     assert sdk.data is not None
     assert sdk.data["is_cancelled"] is True
+
+
+@pytest.mark.asyncio
+async def test_detail_scraper_plain_text_zoom_and_cancellation():
+    """Zoom URLs in plain text become links; cancellation text sets the flag"""
+    from harambe_scrapers.extractor.wayne_commission.detail import (
+        scrape as detail_scrape,
+    )
+
+    html_content = """
+    <html><body>
+    <h1 class="oc-page-title">Ethics Board Meeting - July 15, 2026</h1>
+    <ul class="content-details-list minutes-details-list">
+      <li><span class="minutes-date">July 15, 2026</span></li>
+      <li><span class="field-value">Ethics Board</span></li>
+    </ul>
+    <div class="meeting-container"><p>Meeting has been canceled.</p></div>
+    <div class="meeting-time">Time 9:00 AM - 10:00 AM</div>
+    <div class="meeting-address">
+      <p>7th Floor Meeting Room, Guardian Building, or join at
+      https://zoom.us/j/2234975895.</p>
+    </div>
+    </body></html>
+    """
+
+    session = MagicMock()
+    session.get.return_value = make_response(text=html_content)
+
+    sdk = DetailSDK()
+    await detail_scrape(
+        sdk, "https://test.com", {"isCancelled": "False"}, session=session
+    )
+
+    assert sdk.data is not None
+    zoom_links = [link for link in sdk.data["links"] if "zoom.us" in link["url"]]
+    assert zoom_links == [
+        {"title": "Zoom Meeting Link", "url": "https://zoom.us/j/2234975895"}
+    ]
+    # Cancelled in description text even though the API flag said otherwise
+    assert sdk.data["is_cancelled"] is True

--- a/tests/test_wayne_commission.py
+++ b/tests/test_wayne_commission.py
@@ -387,3 +387,40 @@ async def test_detail_scraper_plain_text_zoom_and_cancellation():
     ]
     # Cancelled in description text even though the API flag said otherwise
     assert sdk.data["is_cancelled"] is True
+
+
+@pytest.mark.asyncio
+async def test_detail_scraper_start_time_only():
+    """Pages that publish only a start time should still produce a meeting"""
+    from harambe_scrapers.extractor.wayne_commission.detail import (
+        scrape as detail_scrape,
+    )
+
+    html_content = """
+    <html><body>
+    <h1 class="oc-page-title">Seniors and Veterans Affairs Committee</h1>
+    <ul class="content-details-list minutes-details-list">
+      <li><span class="minutes-date">January 14, 2026</span></li>
+      <li><span class="field-value">Seniors and Veterans Affairs Committee</span></li>
+    </ul>
+    <div class="meeting-container"><p>Standard Meeting</p></div>
+    <div class="meeting-time">Time09:30 AM</div>
+    <div class="meeting-address">
+      <p>Commission Chambers, Mezzanine, Guardian Building, 500 Griswold,
+      Detroit, MI, 48226</p>
+    </div>
+    </body></html>
+    """
+
+    session = MagicMock()
+    session.get.return_value = make_response(text=html_content)
+
+    sdk = DetailSDK()
+    await detail_scrape(
+        sdk, "https://test.com", {"isCancelled": "False"}, session=session
+    )
+
+    assert sdk.data is not None
+    assert "2026-01-14T09:30:00" in sdk.data["start_time"]
+    assert sdk.data["end_time"] is None
+    assert sdk.data["title"] == "Seniors and Veterans Affairs Committee"


### PR DESCRIPTION
## What's this PR do?

Fixes the Wayne County Commission scraper (all 13 `wayne_*` scraper names), which has been producing **zero meetings** — see Airtable Tech Request #540 / [DOC-2596](https://linear.app/pdw/issue/DOC-2596/wayne-county-commission-scrapers-not-generating-meetings-blocks-all).

**Root cause:** waynecountymi.gov's Akamai bot protection now returns `403 Access Denied` to requests carrying the scraper's hardcoded spoofed browser headers (fake Edge User-Agent, `sec-ch-ua`, `x-b3` tracing headers, a stale session cookie) sent from a non-browser HTTP client. Every calendar API call was rejected, so no meeting URLs were enqueued.

**Fix:** honestly-identified plain HTTP clients are allowed through, so both stages now run over `requests` with a `city-scrapers-det (+repo URL)` User-Agent, and Playwright is dropped from this scraper entirely:

- **Listing:** reads the combined-calendar widget's entity id from the page HTML (with a hardcoded fallback), then uses the same JSON endpoints the calendar widget itself calls: `getcalendars` → `getcalendaritems` → `contentinfo`. Previously the calendar ids were scraped from browser-rendered filter elements.
- **Detail:** meeting pages are server-rendered, so they're parsed with `parsel` instead of driving a browser. Both page layouts (meeting layout and `.small-text` fallback) are preserved.
- **New:** Zoom URLs that appear as plain text in the meeting content (most of them — they're usually not anchors) are now captured as `Zoom Meeting Link` entries, and meetings cancelled only via description text ("Meeting has been canceled.") while the API flag stays false are now marked cancelled (5 such meetings in current data).
- Extends the item window to include next year, dedupes detail URLs shared by multiple calendar items, and adds polite delays between requests.

Output format, scraper names, and the merge pipeline (`merge_harambe_to_latest.py`) are unchanged. No new dependencies — `requests` and `parsel` are already in `Pipfile.lock`.

## Why are we doing this?

Wayne County Commission coverage is the reporter's #1 scraper priority — it represents the entirety of Detroit's county coverage and those meetings are currently missing from the site. The county books meetings irregularly (a "second week" meeting sometimes lands on the first Tuesday), so recurring formulas can't substitute for the scraper.

## Steps to manually test

1. Ensure the project is installed:
```
pipenv sync --dev
```
2. Run the unit tests:
```
pipenv run pytest tests/test_wayne_commission.py -v
```
3. Run the scraper end-to-end (takes ~10–15 min for ~620 meeting pages; no Azure env vars needed for a local run):
```
export PYTHONPATH=$(pwd):$PYTHONPATH
pipenv run python harambe_scrapers/wayne_commission.py
```
4. Inspect `harambe_scrapers/output/wayne_commission_<timestamp>.json`.

Verified against the live site on 2026-07-15: **529 meetings** scraped (2025 + 2026), including **105 upcoming meetings** across Full Commission, Ways & Means, Audit, Public Services, Government Operations, Health & Human Services, Public Safety, Economic Development, Ethics Board, Special Committees, Election Commission, and the Women's Commission — with times, locations, agenda PDFs, and Zoom links.

## Are there any smells or added technical debt to note?

- The listing stage makes one `contentinfo` request per calendar item (~675 requests plus ~620 detail pages per run, throttled at 0.1s/0.25s). That's how the county's own calendar widget works; fine for a daily cron.
- If the county ever tightens Akamai rules to block non-browser clients outright, this scraper would need a different approach (their schedule PDF is a possible fallback source).
- The `COMMISION` classification typo is preserved intentionally for downstream compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mmcv8AuocKBmtybM1oHjhm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mmcv8AuocKBmtybM1oHjhm)_