### PR TITLE
Attribute each Wayne County meeting to its own body's scraper name

### DIFF
--- a/harambe_scrapers/extractor/wayne_commission/common.py
+++ b/harambe_scrapers/extractor/wayne_commission/common.py
@@ -7,6 +7,8 @@ honestly-identified HTTP clients are allowed, so we identify ourselves
 as a scraper and use the same JSON endpoints the calendar widget uses.
 """
 
+import re
+
 import requests
 
 BASE_URL = "https://www.waynecountymi.gov"
@@ -35,3 +37,49 @@ def create_session() -> requests.Session:
         }
     )
     return session
+
+
+# The Documenters platform matches meetings to agencies by the exact
+# scraper name prefix of extras["cityscrapers/id"]. Agency "Wayne County
+# Commission" registers these individual names, keyed here by normalized
+# county-calendar label. Meetings stamped with anything else (including
+# the old comma-joined 13-name string) are silently skipped at import.
+REGISTERED_CALENDAR_SCRAPER_NAMES = {
+    "full commission meeting": "wayne_full_commission",
+    "full commission": "wayne_full_commission",
+    "committee of the whole": "wayne_cow",
+    "audit committee": "wayne_audit",
+    "economic development committee": "wayne_economic_development",
+    "government operations committee": "wayne_government_operations",
+    "health and human services committee": "wayne_health_human_services",
+    ("public safety, judiciary and homeland security committee"): "wayne_public_safety",
+    "public services committee": "wayne_public_services",
+    "ways and means committee": "wayne_ways_means",
+    "election commission": "wayne_election_commission",
+    "building authority": "wayne_building_authority",
+    "ethics board": "wayne_ethics_board",
+    "local emergency planning committee": "wayne_local_emergency_planning",
+    "local emergency planning": "wayne_local_emergency_planning",
+    # The county also has a departmental "Economic Development" calendar
+    # distinct from the commission committee; keep it from colliding with
+    # the registered committee name.
+    "economic development": "wayne_economic_development_events",
+}
+
+# Calendars with no registered agency get a stable derived name; the
+# platform skips them harmlessly until an agency registers that name.
+FALLBACK_SCRAPER_NAME = "wayne_commission"
+
+
+def _normalize_calendar_label(label: str) -> str:
+    label = (label or "").replace("&", "and").replace("’", "'").lower()
+    return " ".join(label.split())
+
+
+def scraper_name_for_calendar(label: str) -> str:
+    """Map a county-calendar label to a per-body scraper name."""
+    normalized = _normalize_calendar_label(label)
+    if normalized in REGISTERED_CALENDAR_SCRAPER_NAMES:
+        return REGISTERED_CALENDAR_SCRAPER_NAMES[normalized]
+    derived = re.sub(r"[^a-z0-9]+", "_", normalized).strip("_")
+    return f"wayne_{derived}" if derived else FALLBACK_SCRAPER_NAME

--- a/harambe_scrapers/extractor/wayne_commission/listing.py
+++ b/harambe_scrapers/extractor/wayne_commission/listing.py
@@ -25,11 +25,13 @@ from harambe_scrapers.extractor.wayne_commission.common import (
     CALENDAR_PAGE_URL,
     DEFAULT_CALENDAR_ENTITY_ID,
     DEFAULT_CALENDAR_ENTITY_TYPE,
+    FALLBACK_SCRAPER_NAME,
     GET_CALENDAR_ITEMS_URL,
     GET_CALENDARS_URL,
     GET_CONTENT_INFO_URL,
     REQUEST_TIMEOUT,
     create_session,
+    scraper_name_for_calendar,
 )
 
 # Delay between per-item contentinfo requests to stay polite
@@ -127,9 +129,19 @@ async def scrape(
 
     calendars = get_calendars(session, entity_id, entity_type)
     calendar_ids = [c["Id"] for c in calendars if c.get("Id")]
+    # Each meeting must carry the scraper name of its own body — the
+    # Documenters platform matches meetings to agencies by that exact name
+    calendar_scraper_names = {
+        c["Id"]: scraper_name_for_calendar(c.get("Label"))
+        for c in calendars
+        if c.get("Id")
+    }
     print(f"[LISTING] Found {len(calendar_ids)} calendars:")
     for calendar in calendars:
-        print(f"[LISTING]   - {calendar.get('Label')}")
+        print(
+            f"[LISTING]   - {calendar.get('Label')} -> "
+            f"{calendar_scraper_names.get(calendar.get('Id'))}"
+        )
 
     if not calendar_ids:
         raise RuntimeError("No calendars found for the county calendar widget")
@@ -173,9 +185,15 @@ async def scrape(
                 continue
             seen_urls.add(meeting_link)
             is_cancelled = info.get("IsCancelled") is not False
+            scraper_name = calendar_scraper_names.get(
+                item.get("CalendarId"), FALLBACK_SCRAPER_NAME
+            )
             await sdk.enqueue(
                 meeting_link,
-                context={"isCancelled": f"{is_cancelled}"},
+                context={
+                    "isCancelled": f"{is_cancelled}",
+                    "scraperName": scraper_name,
+                },
             )
             enqueued += 1
             if enqueued % 20 == 0:

--- a/harambe_scrapers/wayne_commission.py
+++ b/harambe_scrapers/wayne_commission.py
@@ -27,7 +27,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from harambe_scrapers.extractor.wayne_commission.common import create_session
+from harambe_scrapers.extractor.wayne_commission.common import (
+    FALLBACK_SCRAPER_NAME,
+    create_session,
+)
 from harambe_scrapers.extractor.wayne_commission.detail import scrape as detail_scrape
 from harambe_scrapers.extractor.wayne_commission.listing import scrape as listing_scrape
 from harambe_scrapers.observers import DataCollector
@@ -35,14 +38,12 @@ from harambe_scrapers.utils import create_ocd_event
 
 # Constants
 AGENCY_NAME = "Wayne County Commission"
-SCRAPER_NAME = (
-    "wayne_health_human_services,wayne_economic_development,wayne_ethics_board,"
-    "wayne_government_operations,wayne_ways_means,wayne_audit,wayne_public_services,"
-    "wayne_building_authority,wayne_election_commission,wayne_public_safety,wayne_cow,"
-    "wayne_local_emergency_planning,wayne_full_commission"
-)
-# Use shorter name for file output
-OUTPUT_NAME = "wayne_commission"
+# Meetings are attributed per body (wayne_full_commission, wayne_ways_means,
+# etc.) via the county calendar they belong to — the Documenters platform
+# matches meetings to agencies by that exact scraper name. See
+# extractor/wayne_commission/common.py for the calendar mapping.
+# Used for file naming and as the fallback attribution
+OUTPUT_NAME = FALLBACK_SCRAPER_NAME
 TIMEZONE = "America/Detroit"
 START_URL = "https://www.waynecountymi.gov/Government/County-Calendar"
 OUTPUT_DIR = Path("harambe_scrapers/output")
@@ -79,7 +80,7 @@ class WayneCommissionOrchestrator:
     def __init__(self, limit_meetings: int = None):
         self.limit_meetings = limit_meetings  # Optional limit for testing
         self.observer = DataCollector(
-            scraper_name=SCRAPER_NAME,
+            scraper_name=OUTPUT_NAME,
             timezone=TIMEZONE,
         )
         self.session = create_session()
@@ -112,7 +113,7 @@ class WayneCommissionOrchestrator:
             print(f"    ✗ Error extracting {url}: {e}")
             return None
 
-    def transform_to_ocd_format(self, raw_data: dict) -> dict:
+    def transform_to_ocd_format(self, raw_data: dict, scraper_name: str = None) -> dict:
         """Transform raw data to OCD format."""
         # Handle all_day_event field
         all_day = raw_data.get("is_all_day_event")
@@ -124,7 +125,7 @@ class WayneCommissionOrchestrator:
         return create_ocd_event(
             title=raw_data.get("title") or "Wayne County Commission Meeting",
             start_time=raw_data["start_time"],
-            scraper_name=SCRAPER_NAME,
+            scraper_name=scraper_name or FALLBACK_SCRAPER_NAME,
             agency_name=AGENCY_NAME,
             timezone=TIMEZONE,
             description=raw_data.get("description") or "",
@@ -167,7 +168,10 @@ class WayneCommissionOrchestrator:
             await asyncio.sleep(DETAIL_REQUEST_DELAY_SECONDS)
 
             if raw_data and raw_data.get("start_time"):
-                ocd_event = self.transform_to_ocd_format(raw_data)
+                ocd_event = self.transform_to_ocd_format(
+                    raw_data,
+                    scraper_name=detail_info.get("context", {}).get("scraperName"),
+                )
                 await self.observer.on_save_data(ocd_event)
                 # Extract date from start_time for display
                 start_date = raw_data["start_time"][:10]  # Get YYYY-MM-DD

--- a/scripts/merge_harambe_to_latest.py
+++ b/scripts/merge_harambe_to_latest.py
@@ -251,6 +251,21 @@ def main():
         "wayne_cow",
         "wayne_local_emergency_planning",
         "wayne_full_commission",
+        # Derived names for county calendars without a registered agency
+        # (see extractor/wayne_commission/common.py); listed here so old
+        # entries are cleaned from latest.json on every merge
+        "wayne_economic_development_events",
+        "wayne_seniors_and_veterans_services_committee",
+        "wayne_special_committees",
+        "wayne_art_institute_authority",
+        "wayne_board_of_canvassers",
+        "wayne_brownfield_redevelopment_authority",
+        "wayne_commission_youth_council",
+        "wayne_wc_women_s_commission_meetings",
+        "wayne_wc_zoological_authority_meetings",
+        "wayne_parks_and_recreation_events",
+        "wayne_environmental_services",
+        "wayne_commission",
     ]
 
     print(f"Harambe scrapers to process: {len(harambe_scrapers)} scrapers")

--- a/tests/test_wayne_commission.py
+++ b/tests/test_wayne_commission.py
@@ -697,3 +697,136 @@ async def test_detail_scraper_protocol_less_zoom_link():
     assert zoom_links == [
         {"title": "Zoom Meeting Link", "url": "https://zoom.us/j/999888777"}
     ]
+
+
+def test_scraper_name_for_calendar_mapping():
+    """Calendar labels must map to the platform's registered scraper names"""
+    from harambe_scrapers.extractor.wayne_commission.common import (
+        scraper_name_for_calendar,
+    )
+
+    # The 13 registered names on the Wayne County Commission agency
+    assert scraper_name_for_calendar("Full Commission Meeting") == (
+        "wayne_full_commission"
+    )
+    assert scraper_name_for_calendar("Committee of the Whole") == "wayne_cow"
+    assert scraper_name_for_calendar("Audit Committee") == "wayne_audit"
+    assert scraper_name_for_calendar("Economic Development Committee") == (
+        "wayne_economic_development"
+    )
+    assert scraper_name_for_calendar("Government Operations Committee") == (
+        "wayne_government_operations"
+    )
+    assert scraper_name_for_calendar("Health and Human Services Committee") == (
+        "wayne_health_human_services"
+    )
+    assert scraper_name_for_calendar(
+        "Public Safety, Judiciary & Homeland Security Committee"
+    ) == ("wayne_public_safety")
+    assert scraper_name_for_calendar("Public Services Committee") == (
+        "wayne_public_services"
+    )
+    assert scraper_name_for_calendar("Ways & Means Committee") == "wayne_ways_means"
+    assert scraper_name_for_calendar("Election Commission") == (
+        "wayne_election_commission"
+    )
+    assert scraper_name_for_calendar("Building Authority") == (
+        "wayne_building_authority"
+    )
+    assert scraper_name_for_calendar("Ethics Board") == "wayne_ethics_board"
+    assert scraper_name_for_calendar("Local Emergency Planning Committee") == (
+        "wayne_local_emergency_planning"
+    )
+
+    # The departmental Economic Development calendar must NOT collide with
+    # the registered committee name
+    assert scraper_name_for_calendar("Economic Development ") == (
+        "wayne_economic_development_events"
+    )
+
+    # Unregistered calendars get a stable derived name
+    assert scraper_name_for_calendar("Seniors & Veterans Services Committee") == (
+        "wayne_seniors_and_veterans_services_committee"
+    )
+    assert scraper_name_for_calendar("Parks & Recreation Events") == (
+        "wayne_parks_and_recreation_events"
+    )
+
+
+@pytest.mark.asyncio
+async def test_listing_scraper_attributes_scraper_name():
+    """Enqueued meetings must carry their calendar's individual scraper name"""
+    from harambe_scrapers.extractor.wayne_commission.listing import (
+        scrape as listing_scrape,
+    )
+
+    item = {
+        "CalendarId": "cal-ways-means",
+        "Id": "item-1",
+        "MainContentId": "item-1",
+        "Name": "Ways & Means - August 5, 2026",
+        "DateTime": "8/5/2026 12:30:00 PM",
+    }
+    items_response = {"success": True, "data": [{"Items": [item]}]}
+    empty_response = {"success": True, "data": []}
+
+    session = MagicMock()
+
+    def fake_get(url, **kwargs):
+        if "County-Calendar" in url:
+            return make_response(text="<html></html>")
+        if "getcalendars" in url:
+            return make_response(
+                json_data={
+                    "success": True,
+                    "data": [
+                        {"Id": "cal-ways-means", "Label": "Ways & Means Committee"}
+                    ],
+                }
+            )
+        if "contentinfo" in url:
+            return make_response(
+                json_data={
+                    "success": True,
+                    "data": {"Link": "https://example.com/wm", "IsCancelled": False},
+                }
+            )
+        raise AssertionError(f"Unexpected GET {url}")
+
+    post_responses = iter([empty_response, items_response, empty_response])
+    session.get.side_effect = fake_get
+    session.post.side_effect = lambda url, **kwargs: make_response(
+        json_data=next(post_responses)
+    )
+
+    detail_urls = []
+    with patch(
+        "harambe_scrapers.extractor.wayne_commission.listing."
+        "ITEM_REQUEST_DELAY_SECONDS",
+        0,
+    ):
+        await listing_scrape(
+            ListingSDK(detail_urls), "https://test.com", {}, session=session
+        )
+
+    assert detail_urls[0]["context"]["scraperName"] == "wayne_ways_means"
+
+
+def test_transform_uses_per_meeting_scraper_name():
+    """The OCD id must be prefixed with the meeting's own scraper name"""
+    orchestrator = WayneCommissionOrchestrator()
+    orchestrator.current_url = "https://www.waynecountymi.gov/test"
+
+    raw_data = {
+        "title": "Ways & Means Committee - August 5, 2026",
+        "start_time": get_future_datetime(days_ahead=30).isoformat(),
+    }
+
+    result = orchestrator.transform_to_ocd_format(
+        raw_data, scraper_name="wayne_ways_means"
+    )
+    assert result["extras"]["cityscrapers/id"].startswith("wayne_ways_means/")
+
+    # Without a name it falls back to the unregistered default
+    result = orchestrator.transform_to_ocd_format(raw_data)
+    assert result["extras"]["cityscrapers/id"].startswith("wayne_commission/")


### PR DESCRIPTION
## What's this PR do?

Follow-up to #94 (Tech Request #540 / [DOC-2596](https://linear.app/pdw/issue/DOC-2596/wayne-county-commission-scrapers-not-generating-meetings-blocks-all)). Fixes the **second root cause** of the Wayne County outage, discovered while validating production ingestion after #94 merged.

**Problem:** the Documenters platform matches meetings to agencies by the exact scraper-name prefix of `extras["cityscrapers/id"]` — `import_meeting_json` splits the ID on `/` and looks the prefix up in `Agency.scraper_names`. The Wayne County Commission agency registers 13 *individual* names (`wayne_full_commission`, `wayne_ways_means`, …), and all 3,391 historical Wayne meetings in the production DB use those individual prefixes. But this scraper stamped every meeting with the **comma-joined 13-name string**, so no agency ever matched and every Wayne meeting was silently skipped at import ("scraper … not registered") — even with #94's valid feed, production ingested zero. This mismatch has silently dropped harambe Wayne meetings since the Dec 2025 cutover (agency migration date 2025-12-20).

**Fix:**
- Map each county calendar to its body's registered scraper name (`extractor/wayne_commission/common.py`), verified against the production agency's `scraper_names`. The listing stage attaches `scraperName` to each enqueued meeting's context from its `CalendarId`; the orchestrator uses it when building the OCD event.
- Calendars without a registered agency (Seniors & Veterans, Women's Commission, Parks & Rec, etc.) get stable derived `wayne_*` names — production skips them harmlessly until an agency registers that name, at which point meetings flow with no scraper change.
- The departmental "Economic Development" calendar maps to `wayne_economic_development_events` so it can't be misattributed to the registered committee.
- Derived names are added to `merge_harambe_to_latest.py`'s cleanup list so repeated merges stay idempotent.

## Why are we doing this?

Without it, #94's fix produces a perfect feed that production silently discards. This PR is what actually puts Wayne County meetings back on documenters.org.

## Steps to manually test

1. `pipenv run pytest tests/test_wayne_commission.py -v` (21 tests, including calendar→name mapping against the registered names)
2. Full run: `PYTHONPATH=$(pwd) pipenv run python harambe_scrapers/wayne_commission.py`
3. Verify the output's ID prefixes: every meeting should carry an individual `wayne_*` name, none the comma-joined string.

Verified on a full live run (2026-07-15): 552 meetings, 0 comma-joined prefixes, **428 meetings under the 13 registered names (96 upcoming)**, remainder under stable derived names.

## Are there any smells or added technical debt to note?

- The calendar→name mapping is keyed on normalized calendar labels; if the county renames a calendar, meetings fall back to a derived name (skipped by production) rather than breaking — visible in the listing logs which print each calendar's mapping every run.
- Unregistered bodies (e.g. Seniors & Veterans Services Committee, 46 meetings) are scraped and published but won't appear on the site until someone registers an agency with the derived scraper name — worth a staff decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mmcv8AuocKBmtybM1oHjhm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mmcv8AuocKBmtybM1oHjhm)_