### PR TITLE
Add new Wayne scraper names to archive_harambe.py list

### DIFF
--- a/scripts/archive_harambe.py
+++ b/scripts/archive_harambe.py
@@ -36,6 +36,21 @@ HARAMBE_SCRAPERS = [
     "wayne_cow",
     "wayne_local_emergency_planning",
     "wayne_full_commission",
+    # Derived names for county calendars without a registered agency, plus
+    # the fallback name (see extractor/wayne_commission/common.py); keep in
+    # sync with scripts/merge_harambe_to_latest.py
+    "wayne_economic_development_events",
+    "wayne_seniors_and_veterans_services_committee",
+    "wayne_special_committees",
+    "wayne_art_institute_authority",
+    "wayne_board_of_canvassers",
+    "wayne_brownfield_redevelopment_authority",
+    "wayne_commission_youth_council",
+    "wayne_wc_women_s_commission_meetings",
+    "wayne_wc_zoological_authority_meetings",
+    "wayne_parks_and_recreation_events",
+    "wayne_environmental_services",
+    "wayne_commission",
 ]
 
 

--- a/scripts/archive_harambe.py
+++ b/scripts/archive_harambe.py
@@ -8,6 +8,7 @@ from urllib.parse import quote, unquote, urlparse
 
 import aiohttp
 from azure.storage.blob import BlobServiceClient
+from merge_harambe_to_latest import HARAMBE_SCRAPERS
 
 CITY = "det"
 CONTAINER = f"meetings-feed-{CITY}"
@@ -16,42 +17,6 @@ MAX_LINKS = 3
 MAX_CONCURRENT = 2
 REQUEST_DELAY = 4
 TIMEOUT = 10
-
-HARAMBE_SCRAPERS = [
-    "det_dwcpa",
-    "det_great_lakes_water_authority",
-    "det_police_department",
-    "det_police_fire_retirement",
-    "mi_belle_isle",
-    "wayne_health_human_services",
-    "wayne_economic_development",
-    "wayne_ethics_board",
-    "wayne_government_operations",
-    "wayne_ways_means",
-    "wayne_audit",
-    "wayne_public_services",
-    "wayne_building_authority",
-    "wayne_election_commission",
-    "wayne_public_safety",
-    "wayne_cow",
-    "wayne_local_emergency_planning",
-    "wayne_full_commission",
-    # Derived names for county calendars without a registered agency, plus
-    # the fallback name (see extractor/wayne_commission/common.py); keep in
-    # sync with scripts/merge_harambe_to_latest.py
-    "wayne_economic_development_events",
-    "wayne_seniors_and_veterans_services_committee",
-    "wayne_special_committees",
-    "wayne_art_institute_authority",
-    "wayne_board_of_canvassers",
-    "wayne_brownfield_redevelopment_authority",
-    "wayne_commission_youth_council",
-    "wayne_wc_women_s_commission_meetings",
-    "wayne_wc_zoological_authority_meetings",
-    "wayne_parks_and_recreation_events",
-    "wayne_environmental_services",
-    "wayne_commission",
-]
 
 
 def download_latest_json(container=CONTAINER):

--- a/scripts/merge_harambe_to_latest.py
+++ b/scripts/merge_harambe_to_latest.py
@@ -18,6 +18,44 @@ UPCOMING_BLOB = "upcoming.json"
 LOCAL_OUTPUT_DIR = "harambe_scrapers/output"
 START_TIME_KEY = "start_time"
 
+# Every scraper name the harambe pipeline can emit; old entries under these
+# names are cleaned from latest.json on every merge. Also imported by
+# archive_harambe.py so archiving covers the same set.
+HARAMBE_SCRAPERS = [
+    "det_dwcpa",
+    "det_great_lakes_water_authority",
+    "det_police_department",
+    "det_police_fire_retirement",
+    "mi_belle_isle",
+    "wayne_health_human_services",
+    "wayne_economic_development",
+    "wayne_ethics_board",
+    "wayne_government_operations",
+    "wayne_ways_means",
+    "wayne_audit",
+    "wayne_public_services",
+    "wayne_building_authority",
+    "wayne_election_commission",
+    "wayne_public_safety",
+    "wayne_cow",
+    "wayne_local_emergency_planning",
+    "wayne_full_commission",
+    # Derived names for county calendars without a registered agency
+    # (see extractor/wayne_commission/common.py)
+    "wayne_economic_development_events",
+    "wayne_seniors_and_veterans_services_committee",
+    "wayne_special_committees",
+    "wayne_art_institute_authority",
+    "wayne_board_of_canvassers",
+    "wayne_brownfield_redevelopment_authority",
+    "wayne_commission_youth_council",
+    "wayne_wc_women_s_commission_meetings",
+    "wayne_wc_zoological_authority_meetings",
+    "wayne_parks_and_recreation_events",
+    "wayne_environmental_services",
+    "wayne_commission",
+]
+
 
 def get_azure_container_client(container_name: str = DEFAULT_CONTAINER):
     """Get Azure container client."""
@@ -232,41 +270,7 @@ def main():
     print("  Will update: latest.json, upcoming.json, and per-scraper files")
     print()
 
-    harambe_scrapers = [
-        "det_dwcpa",
-        "det_great_lakes_water_authority",
-        "det_police_department",
-        "det_police_fire_retirement",
-        "mi_belle_isle",
-        "wayne_health_human_services",
-        "wayne_economic_development",
-        "wayne_ethics_board",
-        "wayne_government_operations",
-        "wayne_ways_means",
-        "wayne_audit",
-        "wayne_public_services",
-        "wayne_building_authority",
-        "wayne_election_commission",
-        "wayne_public_safety",
-        "wayne_cow",
-        "wayne_local_emergency_planning",
-        "wayne_full_commission",
-        # Derived names for county calendars without a registered agency
-        # (see extractor/wayne_commission/common.py); listed here so old
-        # entries are cleaned from latest.json on every merge
-        "wayne_economic_development_events",
-        "wayne_seniors_and_veterans_services_committee",
-        "wayne_special_committees",
-        "wayne_art_institute_authority",
-        "wayne_board_of_canvassers",
-        "wayne_brownfield_redevelopment_authority",
-        "wayne_commission_youth_council",
-        "wayne_wc_women_s_commission_meetings",
-        "wayne_wc_zoological_authority_meetings",
-        "wayne_parks_and_recreation_events",
-        "wayne_environmental_services",
-        "wayne_commission",
-    ]
+    harambe_scrapers = HARAMBE_SCRAPERS
 
     print(f"Harambe scrapers to process: {len(harambe_scrapers)} scrapers")
     print()


### PR DESCRIPTION
## What's this PR do?

Follow-up to #95. That PR added the derived per-calendar Wayne scraper names (e.g. `wayne_seniors_and_veterans_services_committee`) and the `wayne_commission` fallback to `scripts/merge_harambe_to_latest.py`'s scraper list — but `scripts/archive_harambe.py` (run by the `archive_harambe` job in `.github/workflows/archive.yml`) keeps its own hand-maintained copy of that list, which wasn't updated. Meetings published under any of the new names were silently never submitted to the Wayback Machine.

This mirrors the merge script's full 30-name list into `HARAMBE_SCRAPERS` and adds a comment that the two lists must stay in sync.

## Why are we doing this?

So the source/agenda links of meetings from the newly-named Wayne calendars (and the fallback name) get archived like every other harambe meeting, instead of silently dropping out of the archive pipeline.

## Steps to manually test

1. `python3 -m py_compile scripts/archive_harambe.py`
2. Compare the two lists — they now match exactly (30 entries each):
```
python3 - <<'EOF'
import ast, re
a = ast.literal_eval(re.search(r'HARAMBE_SCRAPERS = (\[.*?\])', open('scripts/archive_harambe.py').read(), re.S).group(1))
m = ast.literal_eval(re.search(r'harambe_scrapers = (\[.*?\])', open('scripts/merge_harambe_to_latest.py').read(), re.S).group(1))
assert set(a) == set(m) and len(a) == len(m) == 30
EOF
```

## Are there any smells or added technical debt to note?

The list is still duplicated between the two scripts (this PR keeps them in sync manually and documents that requirement). Extracting a shared module both scripts import would remove the drift risk for good — happy to do that if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBJ4p248oPmmY3ZXKqJsjD

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBJ4p248oPmmY3ZXKqJsjD)_