### PR TITLE
Republish scraper status badges from the harambe merge step

### DIFF
--- a/scripts/merge_harambe_to_latest.py
+++ b/scripts/merge_harambe_to_latest.py
@@ -337,15 +337,20 @@ def write_status_badges(
         print(f"  {STATUS_CONTAINER_ENV} not set — skipping status badges")
         return
 
-    counts = Counter(scraper_name_from_meeting(m) for m in meetings)
-    date_str = datetime.now(ZoneInfo(STATUS_BADGE_TZ)).strftime("%Y-%m-%d")
-    container_client = get_azure_container_client(container_name)
+    try:
+        counts = Counter(scraper_name_from_meeting(m) for m in meetings)
+        date_str = datetime.now(ZoneInfo(STATUS_BADGE_TZ)).strftime("%Y-%m-%d")
+        container_client = get_azure_container_client(container_name)
+    except Exception as e:
+        print(f"  Skipping status badges — could not init status container: {e}")
+        return
 
     written = 0
     empty = []
     for name in scraper_names:
-        status = STATUS_RUNNING if counts.get(name, 0) else EMPTY_RUN_STATUS
-        if not counts.get(name, 0):
+        has = counts.get(name, 0)
+        status = STATUS_RUNNING if has else EMPTY_RUN_STATUS
+        if not has:
             empty.append(name)
         try:
             container_client.get_blob_client(f"{name}.svg").upload_blob(

--- a/scripts/merge_harambe_to_latest.py
+++ b/scripts/merge_harambe_to_latest.py
@@ -1,11 +1,13 @@
 import json
 import os
+from collections import Counter
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List
+from zoneinfo import ZoneInfo
 
 try:
-    from azure.storage.blob import BlobServiceClient
+    from azure.storage.blob import BlobServiceClient, ContentSettings
 
     AZURE_AVAILABLE = True
 except ImportError:
@@ -55,6 +57,49 @@ HARAMBE_SCRAPERS = [
     "wayne_environmental_services",
     "wayne_commission",
 ]
+
+# Status-badge publishing. The harambe pipeline replaced the conventional Scrapy
+# spiders for these scrapers but never re-implemented Scrapy's StatusExtension,
+# so their city-scrapers-status/<name>.svg badges went stale. The Documenters
+# report page and Airtable status sync read these badges, so we republish them
+# here. Format mirrors city_scrapers_core.extensions.status: Documenters parses
+# the FIRST <text> element as the status word.
+STATUS_CONTAINER_ENV = "AZURE_STATUS_CONTAINER"
+STATUS_BADGE_TZ = "America/Detroit"
+STATUS_RUNNING = "running"
+STATUS_FAILING = "failing"
+STATUS_COLORS = {STATUS_RUNNING: "#44cc11", STATUS_FAILING: "#cb2431"}
+# Status for a scraper that produced 0 meetings in an otherwise-successful run.
+# The merge only runs after a successful scrape (the listing stage raises on a
+# systemically empty calendar), so 0 meetings means the body is simply empty,
+# not broken — mark it "running". Genuine breakage fails the job (badges are
+# left untouched) and "gone dark" is owned by Documenters' days_broken health
+# detection. Flip to STATUS_FAILING for city_scrapers_core's 0-items-is-failing
+# rule (noisier: empty bodies then read failing).
+EMPTY_RUN_STATUS = STATUS_RUNNING
+
+STATUS_BADGE_SVG = """
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="144" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="a">
+        <rect width="144" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#a)">
+        <path fill="#555" d="M0 0h67v20H0z"/>
+        <path fill="{color}" d="M67 0h77v20H67z"/>
+        <path fill="url(#b)" d="M0 0h144v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+        <text x="345" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">{status}</text>
+        <text x="345" y="140" transform="scale(.1)">{status}</text>
+        <text x="1045" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">{date}</text>
+        <text x="1045" y="140" transform="scale(.1)">{date}</text>
+    </g>
+</svg>
+"""  # noqa: E501
 
 
 def get_azure_container_client(container_name: str = DEFAULT_CONTAINER):
@@ -257,6 +302,68 @@ def filter_upcoming_meetings(meetings: List[Dict]) -> List[Dict]:
     return upcoming
 
 
+def scraper_name_from_meeting(meeting: Dict) -> str:
+    """Return the per-body scraper name encoded as the prefix of a meeting's
+    cityscrapers/id (see harambe_scrapers/utils.generate_id: "<name>/<ts>/...")."""
+    scraper_id = (
+        meeting.get("extras", {}).get("cityscrapers/id")
+        or meeting.get("extras", {}).get("cityscrapers.org/id")
+        or ""
+    )
+    return scraper_id.split("/", 1)[0]
+
+
+def build_status_svg(status: str, date_str: str) -> str:
+    return STATUS_BADGE_SVG.format(
+        color=STATUS_COLORS[status], status=status, date=date_str
+    )
+
+
+def write_status_badges(
+    meetings: List[Dict],
+    scraper_names: List[str],
+    container_name: str = "",
+) -> None:
+    """Publish a per-scraper SVG status badge to the status container.
+
+    Reaching the merge step means the scrape succeeded (the listing stage raises
+    on a systemically empty calendar), so every scraper the pipeline owns is
+    marked "running" — a 0-meeting body is empty, not broken (EMPTY_RUN_STATUS).
+    Genuine breakage fails the job and leaves badges untouched; "gone dark" is
+    owned by Documenters' days_broken health detection. Empty bodies are logged.
+    """
+    container_name = container_name or os.getenv(STATUS_CONTAINER_ENV)
+    if not container_name:
+        print(f"  {STATUS_CONTAINER_ENV} not set — skipping status badges")
+        return
+
+    counts = Counter(scraper_name_from_meeting(m) for m in meetings)
+    date_str = datetime.now(ZoneInfo(STATUS_BADGE_TZ)).strftime("%Y-%m-%d")
+    container_client = get_azure_container_client(container_name)
+
+    written = 0
+    empty = []
+    for name in scraper_names:
+        status = STATUS_RUNNING if counts.get(name, 0) else EMPTY_RUN_STATUS
+        if not counts.get(name, 0):
+            empty.append(name)
+        try:
+            container_client.get_blob_client(f"{name}.svg").upload_blob(
+                build_status_svg(status, date_str),
+                overwrite=True,
+                content_settings=ContentSettings(
+                    content_type="image/svg+xml", cache_control="no-cache"
+                ),
+            )
+            written += 1
+        except Exception as e:
+            print(f"  Failed to write status badge for {name}: {e}")
+
+    if empty:
+        print(f"  No meetings this run (marked {EMPTY_RUN_STATUS}): {', '.join(empty)}")
+    print(f"  Wrote {written}/{len(scraper_names)} status badges ({date_str})")
+
+
 def main():
     print("=" * 70)
     print("Merging Harambe Scraper Outputs with Production Data")
@@ -313,6 +420,9 @@ def main():
 
     print("\nUploading individual scraper files...")
     upload_scraper_files_to_azure(LOCAL_OUTPUT_DIR, container_name)
+
+    print("\nWriting scraper status badges...")
+    write_status_badges(harambe_meetings, harambe_scrapers)
 
     print()
     print("=" * 70)

--- a/tests/test_merge_harambe_to_latest.py
+++ b/tests/test_merge_harambe_to_latest.py
@@ -174,7 +174,43 @@ def test_write_status_badges_marks_all_running(mock_blob_service):
     assert "running" in lepc_svg and "#44cc11" in lepc_svg
 
 
-def test_write_status_badges_skipped_without_container():
-    """No container arg and no env var -> no-op, no Azure access, no crash."""
+@patch("scripts.merge_harambe_to_latest.BlobServiceClient")
+def test_write_status_badges_skipped_without_container(mock_blob_service):
+    """No container arg and no env var -> no-op, Azure never touched, no crash."""
     with patch.dict(os.environ, {}, clear=True):
         write_status_badges([_meeting("wayne_audit")], ["wayne_audit"])
+    mock_blob_service.from_connection_string.assert_not_called()
+
+
+@patch("scripts.merge_harambe_to_latest.BlobServiceClient")
+def test_write_status_badges_isolates_per_name_failure(mock_blob_service):
+    """One badge write raising doesn't abort the loop (or the merge job) — the
+    remaining scrapers still get published."""
+    mock_container = Mock()
+    mock_blob_service.from_connection_string.return_value.get_container_client.return_value = (  # noqa: E501
+        mock_container
+    )
+    blobs = {}
+
+    def get_blob_client(name):
+        client = blobs.setdefault(name, Mock())
+        if name == "wayne_audit.svg":
+            client.upload_blob.side_effect = RuntimeError("boom")
+        return client
+
+    mock_container.get_blob_client.side_effect = get_blob_client
+    names = ["wayne_audit", "wayne_public_services"]
+
+    with patch.dict(
+        os.environ, {"AZURE_ACCOUNT_NAME": "test", "AZURE_ACCOUNT_KEY": "test"}
+    ):
+        write_status_badges([], names, container_name="city-scrapers-status")
+
+    blobs["wayne_public_services.svg"].upload_blob.assert_called_once()
+
+
+@patch("scripts.merge_harambe_to_latest.get_azure_container_client")
+def test_write_status_badges_swallows_init_failure(mock_get_client):
+    """A failure acquiring the status container must not break the merge."""
+    mock_get_client.side_effect = ValueError("no creds")
+    write_status_badges([_meeting("wayne_audit")], ["wayne_audit"], container_name="c")

--- a/tests/test_merge_harambe_to_latest.py
+++ b/tests/test_merge_harambe_to_latest.py
@@ -4,17 +4,23 @@ Unit tests for scripts/merge_harambe_to_latest.py
 
 import json
 import os
+import re
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
 
 from scripts.merge_harambe_to_latest import (
+    STATUS_FAILING,
+    STATUS_RUNNING,
+    build_status_svg,
     download_blob_from_azure,
     filter_out_scrapers,
     filter_upcoming_meetings,
     read_harambe_from_local,
+    scraper_name_from_meeting,
     upload_to_azure,
+    write_status_badges,
 )
 
 
@@ -116,3 +122,59 @@ def test_upload_to_azure(mock_blob_service):
 
     assert len(lines) == 2
     assert json.loads(lines[0])["id"] == "m1"
+
+
+def _meeting(scraper_name):
+    return {"extras": {"cityscrapers/id": f"{scraper_name}/202607161000/x/foo"}}
+
+
+def test_scraper_name_from_meeting_uses_id_prefix():
+    """Name is the id prefix — no substring collision between a base name and a
+    longer derived one (wayne_economic_development vs ..._events)."""
+    assert scraper_name_from_meeting(_meeting("wayne_audit")) == "wayne_audit"
+    assert (
+        scraper_name_from_meeting(_meeting("wayne_economic_development_events"))
+        == "wayne_economic_development_events"
+    )
+    assert scraper_name_from_meeting({"extras": {}}) == ""
+
+
+def test_build_status_svg_first_text_is_status_word():
+    """Documenters parses the FIRST <text> element — it must be the status word."""
+    svg = build_status_svg(STATUS_RUNNING, "2026-07-17")
+    first_text = re.search(r"<text[^>]*>([^<]+)</text>", svg).group(1)
+    assert first_text == "running"
+    assert "#44cc11" in svg and "2026-07-17" in svg
+    assert "#cb2431" in build_status_svg(STATUS_FAILING, "2026-07-17")
+
+
+@patch("scripts.merge_harambe_to_latest.BlobServiceClient")
+def test_write_status_badges_marks_all_running(mock_blob_service):
+    """A successful merge marks every scraper running — a body with 0 meetings
+    is empty, not broken (EMPTY_RUN_STATUS)."""
+    mock_container = Mock()
+    mock_blob_service.from_connection_string.return_value.get_container_client.return_value = (  # noqa: E501
+        mock_container
+    )
+    blobs = {}
+    mock_container.get_blob_client.side_effect = lambda n: blobs.setdefault(n, Mock())
+
+    meetings = [_meeting("wayne_audit"), _meeting("wayne_audit")]
+    names = ["wayne_audit", "wayne_local_emergency_planning"]
+
+    with patch.dict(
+        os.environ, {"AZURE_ACCOUNT_NAME": "test", "AZURE_ACCOUNT_KEY": "test"}
+    ):
+        write_status_badges(meetings, names, container_name="city-scrapers-status")
+
+    audit_svg = blobs["wayne_audit.svg"].upload_blob.call_args[0][0]
+    lepc_svg = blobs["wayne_local_emergency_planning.svg"].upload_blob.call_args[0][0]
+    assert "running" in audit_svg and "#44cc11" in audit_svg
+    # 0 meetings but still running (empty != failed)
+    assert "running" in lepc_svg and "#44cc11" in lepc_svg
+
+
+def test_write_status_badges_skipped_without_container():
+    """No container arg and no env var -> no-op, no Azure access, no crash."""
+    with patch.dict(os.environ, {}, clear=True):
+        write_status_badges([_meeting("wayne_audit")], ["wayne_audit"])


### PR DESCRIPTION
## What's this PR do?

Republishes the `city-scrapers-status/<name>.svg` status badge for each harambe
scraper at the end of `scripts/merge_harambe_to_latest.py`. Reaching the merge
step means the scrape succeeded (the listing stage `raise`s on a systemically
empty calendar), so every scraper the pipeline owns is marked **running**; a
body that produced 0 meetings this run is empty, not broken, and is logged.

## Why are we doing this?

The harambe pipeline replaced the conventional Scrapy spiders for Wayne County
(and the other harambe scrapers), but nothing re-implemented Scrapy's
`StatusExtension` — so their status badges froze at the last conventional run
(2025-11-28). The Documenters report page and the Airtable status sync read
those badges, so every migrated scraper's status is now wrong: most read a
lucky-stale `running`, and `wayne_local_emergency_planning` is stuck on
`failing`, which also poisons the whole **Wayne County Commission** agency's
Airtable status (any-fail aggregate). Follow-up to #94 / #95 / #96 (DOC-2596).

## Semantics — why 0 meetings ⇒ running (not failing)

`city_scrapers_core`'s `StatusExtension` treats 0 items as `failing`. For the
harambe multi-body extractor that's the wrong signal: the listing stage already
fails the whole job loudly on systemic breakage, and "gone dark" is owned by
Documenters' `days_broken` health detection. So a per-body 0-count here means
that body simply had no meetings. Flip the one `EMPTY_RUN_STATUS` constant to
`STATUS_FAILING` to restore the core rule if preferred.

## Steps to manually test

1. `pytest tests/test_merge_harambe_to_latest.py`
2. Trigger the `Cron` workflow (`workflow_dispatch`); confirm the `wayne_*.svg`
   badges in the status container update to today's date and read `running`.

## Notes / follow-ups

- **`wayne_local_emergency_planning` has no source calendar.** Verified against
  the live OpenCities API: the county's combined-calendar widget exposes 23
  calendars and none is the Local Emergency Planning Committee, so this name
  always yields 0 meetings. This PR makes it read `running` (empty) instead of a
  false `failing`; the cleaner fix is to **de-register that name on Documenters**
  (separate, Documenters-side change).
- The SVG template is duplicated from `city_scrapers_core` rather than imported,
  to keep this standalone script dependency-light (matching the other harambe
  scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
